### PR TITLE
revert(shell): Switch back to Fish from ZSH

### DIFF
--- a/home/sinh/Drgnfly.nix
+++ b/home/sinh/Drgnfly.nix
@@ -56,7 +56,7 @@
         warp.enable = false;
       };
       shell.fish.enable = true;
-      shell.zsh.enable = true;
+      shell.zsh.enable = false;
       starship.enable = true;
       multiplexers.zellij.enable = true;
       editor.neovim.enable = true;

--- a/modules/home/cli-apps/utilities/default.nix
+++ b/modules/home/cli-apps/utilities/default.nix
@@ -95,7 +95,7 @@ in
       atuin = {
         enable = true;
         enableFishIntegration = true;
-        enableZshIntegration = true;
+        enableZshIntegration = false;
         flags = [ "--disable-up-arrow" ]; # Use Ctrl+R instead, keep up-arrow for normal history
         settings = {
           # Sync settings
@@ -124,7 +124,7 @@ in
       zoxide = {
         enable = true;
         enableFishIntegration = true;
-        enableZshIntegration = true;
+        enableZshIntegration = false;
       };
     };
 

--- a/modules/nixos/users/sinh/default.nix
+++ b/modules/nixos/users/sinh/default.nix
@@ -1,6 +1,6 @@
 { config, pkgs, ... }:
 {
-  programs.zsh.enable = true;
+  programs.fish.enable = true;
 
   users = {
     # Define plugdev group for QMK/udev rules
@@ -24,7 +24,7 @@
       ]
       ++ (if config.virtualisation.virtualbox.host.enable or false then [ "vboxusers" ] else [ ]);
 
-      shell = pkgs.zsh;
+      shell = pkgs.fish;
 
       # Use SOPS-managed password hash when available
       hashedPasswordFile =


### PR DESCRIPTION
## Summary
- Reverts default shell from ZSH to Fish due to atuin history recording failing with zsh-vi-mode (preexec hook conflicts)
- Disables ZSH at config level only — module files preserved for future use
- Disables atuin/zoxide ZSH integrations

## Changes
- `home/sinh/Drgnfly.nix`: `shell.zsh.enable = false`
- `modules/nixos/users/sinh/default.nix`: shell back to `pkgs.fish`
- `modules/home/cli-apps/utilities/default.nix`: atuin + zoxide `enableZshIntegration = false`

## Test plan
- [ ] `sudo sys test` builds successfully
- [ ] Login shell is fish after rebuild
- [ ] Atuin works correctly in fish (Ctrl+R, history recording)

🤖 Generated with [Claude Code](https://claude.com/claude-code)