### PR TITLE
fix(niri): Remove forced workspace assignment for Ghostty

### DIFF
--- a/modules/home/wm/niri/niri_config/config.kdl
+++ b/modules/home/wm/niri/niri_config/config.kdl
@@ -210,7 +210,6 @@ window-rule {
 // Terminal -> open maximized on main-term
 window-rule {
     match app-id="com.mitchellh.ghostty"
-    open-on-workspace "main-term"
     open-maximized true
 }
 


### PR DESCRIPTION
## Summary
- Removed `open-on-workspace "main-term"` rule for Ghostty, allowing it to open on any workspace instead of being forced to `main-term`

## Test plan
- [ ] Open Ghostty and verify it opens on the current workspace
- [ ] Confirm Ghostty still opens maximized

🤖 Generated with [Claude Code](https://claude.com/claude-code)