### PR TITLE
fix(direnv): Move direnv to utilities module for proper Fish integration

### DIFF
--- a/modules/home/cli-apps/utilities/default.nix
+++ b/modules/home/cli-apps/utilities/default.nix
@@ -126,6 +126,13 @@ in
         enableFishIntegration = true;
         enableZshIntegration = false;
       };
+
+      direnv = {
+        enable = true;
+        enableFishIntegration = true;
+        enableZshIntegration = false;
+        nix-direnv.enable = true;
+      };
     };
 
     xdg.mimeApps = {

--- a/modules/home/cli-apps/zsh/default.nix
+++ b/modules/home/cli-apps/zsh/default.nix
@@ -21,12 +21,6 @@ in
         enableZshIntegration = true;
       };
 
-      direnv = {
-        enable = true;
-        enableZshIntegration = true;
-        nix-direnv.enable = true; # Better nix integration
-      };
-
       zsh = {
         enable = true;
         enableCompletion = true;

--- a/systems/x86_64-linux/Drgnfly/default.nix
+++ b/systems/x86_64-linux/Drgnfly/default.nix
@@ -170,7 +170,6 @@
     parted
     gptfdisk
     lm_sensors
-    direnv
     devenv
     nix-tree
     yq

--- a/systems/x86_64-linux/Emberroot/default.nix
+++ b/systems/x86_64-linux/Emberroot/default.nix
@@ -197,7 +197,6 @@
     parted
     gptfdisk
     lm_sensors
-    direnv
     devenv
     nix-tree
     yq


### PR DESCRIPTION
## Summary
- Move `programs.direnv` from zsh module to utilities module (alongside fzf/atuin/zoxide) with explicit Fish integration enabled and zsh disabled
- Remove redundant system-level `direnv` package from Drgnfly and Emberroot — home-manager's `programs.direnv.enable` already provides the binary + proper shell hooks
- Root cause: direnv was locked inside the zsh module, so hosts with `shell.zsh.enable = false` (like Drgnfly) got no Fish hook, causing raw ANSI escape codes to leak into the terminal

## Test plan
- [ ] Run `sudo sys test` on Drgnfly
- [ ] Open new Fish terminal, `cd` into a direnv-managed repo (e.g. avodah)
- [ ] Verify direnv loads cleanly without escape code garbage
- [ ] Verify `fish -c "functions __direnv_export_eval"` shows the hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)