### PR TITLE
fix(niri): Set laptop display scale to 1.5

### DIFF
--- a/modules/home/wm/niri/niri_config/config.kdl
+++ b/modules/home/wm/niri/niri_config/config.kdl
@@ -31,7 +31,7 @@ input {
 // Can use connector name (eDP-1) or "Manufacturer Model Serial"
 output "LG Display 0x06AA Unknown" {
     mode "3840x2400@60.000"
-    scale 1.0
+    scale 1.5
     position x=0 y=0
 }
 


### PR DESCRIPTION
## Summary
- Set laptop display (LG Display 0x06AA) scale from 1.0 to 1.5 for more readable text and UI elements at native 3840x2400 resolution

## Test plan
- [x] Tested live with `niri msg output` — 1.5 scale confirmed readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)