### PR TITLE
fix(wifi): Specify wireless interface to prevent wpa_supplicant race

### DIFF
--- a/modules/nixos/wifi/default.nix
+++ b/modules/nixos/wifi/default.nix
@@ -274,6 +274,12 @@ in
       default = true;
       description = "Allow user control via wpa_cli";
     };
+
+    interfaces = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "Wireless interfaces to use (e.g. [ \"wlp9s0\" ]). Empty list uses auto-detection.";
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -289,6 +295,7 @@ in
       secretsFile = config.sops.secrets."wifi/credentials".path;
       inherit (cfg) userControlled;
       networks = sharedNetworks // cfg.extraNetworks;
-    };
+    }
+    // lib.optionalAttrs (cfg.interfaces != [ ]) { inherit (cfg) interfaces; };
   };
 }

--- a/systems/x86_64-linux/Drgnfly/default.nix
+++ b/systems/x86_64-linux/Drgnfly/default.nix
@@ -44,6 +44,7 @@
     # network
     stubby.enable = true;
     wifi.enable = true;
+    wifi.interfaces = [ "wlp9s0" ];
 
     sops.enable = true;
 


### PR DESCRIPTION
## Summary
- Add `modules.wifi.interfaces` option to explicitly set wireless interfaces instead of relying on auto-detection
- Set `wifi.interfaces = [ "wlp9s0" ]` on Drgnfly to fix wpa_supplicant failing on first boot

## Root Cause
The auto-detect start script globs `/sys/class/net/*` which races with udev renaming `wlan0` → `wlp9s0`. The glob captures `wlan0`, but by the time `find` accesses it, udev has already renamed it — causing an unbound variable crash.

## How the Fix Works
Specifying interfaces explicitly makes NixOS generate a per-interface `wpa_supplicant-wlp9s0.service` with:
```
After=sys-subsystem-net-devices-wlp9s0.device
Requires=sys-subsystem-net-devices-wlp9s0.device
```
This ensures the service only starts after udev has finished setting up the device.

## Test plan
- [x] `nix build .#nixosConfigurations.Drgnfly.config.system.build.toplevel` succeeds
- [x] Generated service unit contains correct device dependency
- [ ] Reboot Drgnfly and verify wpa_supplicant starts on first attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)