### PR TITLE
feat(niri): Update focus-ring and add window rules

### DIFF
--- a/modules/home/wm/niri/niri_config/config.kdl
+++ b/modules/home/wm/niri/niri_config/config.kdl
@@ -86,9 +86,11 @@ layout {
     default-column-width { proportion 0.5; }
 
     focus-ring {
-        width 2
-        active-color "#EEB48A"
-        inactive-color "#4e2510"
+        on
+        width 4
+        active-color "#7fc8ff"
+        inactive-color "#505050"
+        urgent-color "#9b0000"
     }
 
     border {
@@ -225,6 +227,8 @@ window-rule {
     match app-id="org.telegram.desktop"
     match app-id="ViberPC"
     open-on-workspace "chat"
+    open-maximized true
+    open-maximized-to-edges false
     open-focused false
 }
 
@@ -240,6 +244,17 @@ window-rule {
     match app-id="superProductivity"
     open-on-workspace "email"
     open-focused false
+}
+
+// Telegram Media viewer -> floating, centered, 1/3 screen size
+window-rule {
+    match app-id=r#"^org\.telegram\.desktop$"# title="^Media viewer$"
+    open-floating true
+    open-fullscreen false
+    open-focused true
+    default-column-width { proportion 0.33333; }
+    default-window-height { proportion 0.33333; }
+    default-floating-position x=0 y=355 relative-to="top"
 }
 
 // Keybindings


### PR DESCRIPTION
## Summary
- Update focus-ring to wider (4px) blue theme with urgent color
- Add `open-maximized` for chat apps (Signal, Telegram, Viber)
- Add Telegram Media viewer rule: floating, centered, 1/3 screen size with focus on open

## Test plan
- [x] Focus-ring styling verified
- [x] Chat apps open maximized on "chat" workspace
- [x] Telegram Media viewer opens floating and centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)