### PR TITLE
fix(stubby): Fix encrypted DNS routing through localhost

### DIFF
--- a/modules/nixos/default-desktop/default.nix
+++ b/modules/nixos/default-desktop/default.nix
@@ -47,7 +47,7 @@ in
       }
     ];
 
-    networking.nameservers = [
+    networking.nameservers = mkDefault [
       "1.1.1.1"
       "8.8.8.8"
       "8.8.4.4"

--- a/modules/nixos/stubby/default.nix
+++ b/modules/nixos/stubby/default.nix
@@ -20,25 +20,30 @@ in
           {
             address_data = "1.1.1.1";
             tls_auth_name = "cloudflare-dns.com";
-            tls_pubkey_pinset = [
-              {
-                digest = "sha256";
-                value = "4pqQ+yl3lAtRvKdoCCUR8iDmA53I+cJ7orgBLiF08kQ=";
-              }
-            ];
           }
           {
             address_data = "1.0.0.1";
             tls_auth_name = "cloudflare-dns.com";
-            tls_pubkey_pinset = [
-              {
-                digest = "sha256";
-                value = "4pqQ+yl3lAtRvKdoCCUR8iDmA53I+cJ7orgBLiF08kQ=";
-              }
-            ];
+          }
+          {
+            address_data = "2606:4700:4700::1111";
+            tls_auth_name = "cloudflare-dns.com";
+          }
+          {
+            address_data = "2606:4700:4700::1001";
+            tls_auth_name = "cloudflare-dns.com";
           }
         ];
       };
     };
+
+    # Route all DNS through Stubby
+    networking.nameservers = lib.mkForce [
+      "127.0.0.1"
+      "::1"
+    ];
+
+    # Prevent DHCP from overwriting resolv.conf
+    networking.dhcpcd.extraConfig = "nohook resolv.conf";
   };
 }


### PR DESCRIPTION
## Summary
- Removed outdated `tls_pubkey_pinset` from Stubby config — stale certificate pins caused SERVFAIL on all queries. `tls_auth_name` validation is sufficient and won't break on cert rotation.
- Added IPv6 Cloudflare upstream servers (`2606:4700:4700::1111`, `2606:4700:4700::1001`)
- Forced `networking.nameservers` to `127.0.0.1` and `::1` via `mkForce` so DNS routes through Stubby
- Blocked DHCP from overwriting `/etc/resolv.conf` with ISP nameservers
- Wrapped default-desktop nameservers with `mkDefault` so Stubby's `mkForce` takes clean priority

## Test plan
- [x] `sudo sys test` builds successfully
- [x] `/etc/resolv.conf` shows only `127.0.0.1` and `::1`
- [x] `dig @127.0.0.1 cloudflare.com` returns A records (not SERVFAIL)
- [x] `dig cloudflare.com` routes through `127.0.0.1` (Stubby)

🤖 Generated with [Claude Code](https://claude.com/claude-code)