### PR TITLE
feat(coding): Add OpenCode AI coding agent

### DIFF
--- a/home/sinh/Drgnfly.nix
+++ b/home/sinh/Drgnfly.nix
@@ -73,6 +73,7 @@
       editor.vscode.enable = true;
       docker.enable = true;
       claudecode.enable = true;
+      opencode.enable = true;
       super-productivity.enable = false;
       devbox.enable = true;
       flutter.enable = true;

--- a/modules/home/coding/opencode/default.nix
+++ b/modules/home/coding/opencode/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  pkgs,
+  config,
+  namespace,
+  ...
+}:
+with lib;
+let
+  cfg = config.${namespace}.coding.opencode;
+in
+{
+  options.${namespace}.coding.opencode = {
+    enable = mkEnableOption "OpenCode AI coding agent";
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = with pkgs; [
+      opencode
+    ];
+  };
+}


### PR DESCRIPTION
## Summary
- Add home-manager module for OpenCode (`sinh-x.coding.opencode`) following the same pattern as Claude Code
- Enable OpenCode on Drgnfly

## Test plan
- [ ] `sudo sys test` on Drgnfly to verify build
- [ ] Run `opencode` to confirm binary is available
- [ ] Configure AI provider via `/connect`

🤖 Generated with [Claude Code](https://claude.com/claude-code)