### PR TITLE
feat(ssh): Add phone SSH key and enable Tailscale SSH on Drgnfly

### DIFF
--- a/modules/nixos/users/sinh/default.nix
+++ b/modules/nixos/users/sinh/default.nix
@@ -35,6 +35,7 @@
 
       openssh.authorizedKeys.keys = [
         "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCh+hN2O6uIjq/JEftHeIM8JWl0mL9IKBgl1+PlrGUPFonHzCQDcKuIyTODOj2m+L99eGB8wLQovJhZTbAfQzjHnR9qbGVWTZPxGg0XI7VSOkTX0oM1UgLNzANyhrEvdJUXuO64PTP0JwNa2nDR92N3Tg1kugaeIZ83493aqQT7FnLwT9VzrO1FFdqmrWtgpKZyjoQzEOXk13AvTIjItcx0MJTtePh9ogJwmSleR42FBT++U8otLbx8iCov7l7n/PUSiJH2blrsSZtg0KT4r05vbHcZVtdODWWxlumLA3Kjnv6VCXnpjOnLbs+eds/FyugT8oxOjsx3yFQLzYbXWJBR sinh"
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHyv4ZIwT4yAgmBN208sQk6AI9qfzthudnO1qcLGJkrc" # phone
       ];
 
       packages = [ pkgs.home-manager ];

--- a/systems/x86_64-linux/Drgnfly/default.nix
+++ b/systems/x86_64-linux/Drgnfly/default.nix
@@ -219,7 +219,10 @@
     };
   };
 
-  services.tailscale.enable = true;
+  services.tailscale = {
+    enable = true;
+    extraSetFlags = [ "--ssh" ];
+  };
 
   programs.steam.enable = true;
 


### PR DESCRIPTION
## Summary
- Add phone ed25519 SSH key to authorized keys (all hosts)
- Enable Tailscale SSH on Drgnfly for keyless phone access

## Test plan
- [ ] `sudo sys rebuild` on Drgnfly
- [ ] Verify SSH connection from phone via Tailscale
- [ ] Verify `zellij attach` works over the connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)