### PR TITLE
chore(claude-code): Update overlay to v2.1.52

### DIFF
--- a/overlays/claude-code/default.nix
+++ b/overlays/claude-code/default.nix
@@ -1,12 +1,56 @@
 # Overlay to get latest Claude Code version
-# Claude Code bundles all deps, so npmDepsHash can be empty
-_: _final: prev: {
-  claude-code = prev.claude-code.overrideAttrs (_oldAttrs: rec {
-    version = "2.1.38";
+# The npm tarball bundles all deps, so we build from scratch instead of
+# fighting buildNpmPackage's npmConfigHook lockfile validation.
+{ lib, ... }:
+_final: prev:
+let
+  version = "2.1.52";
+in
+{
+  claude-code = prev.stdenv.mkDerivation {
+    pname = "claude-code";
+    inherit version;
+
     src = prev.fetchurl {
       url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
-      hash = "sha256-+o8u2I7EKv10+SUaaf9HdRLl1CxOHuKVm4KzilJHmkk=";
+      hash = "sha256-MjKXEH5w+Kuw4joeA6BsgtBEfbKzcjGpRbabnxkyJuU=";
     };
-    npmDepsHash = "";
-  });
+
+    nativeBuildInputs = [ prev.makeWrapper ];
+
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/lib/node_modules/@anthropic-ai/claude-code
+      cp -r . $out/lib/node_modules/@anthropic-ai/claude-code
+
+      mkdir -p $out/bin
+      makeWrapper ${prev.nodejs}/bin/node $out/bin/claude \
+        --add-flags "$out/lib/node_modules/@anthropic-ai/claude-code/cli.js" \
+        --set DISABLE_AUTOUPDATER 1 \
+        --set DISABLE_INSTALLATION_CHECKS 1 \
+        --unset DEV \
+        --prefix PATH : ${
+          lib.makeBinPath (
+            with prev;
+            [
+              procps
+              bubblewrap
+              socat
+            ]
+          )
+        }
+
+      runHook postInstall
+    '';
+
+    meta = with lib; {
+      description = "CLI for Claude AI assistant";
+      homepage = "https://github.com/anthropics/claude-code";
+      license = licenses.unfree;
+      mainProgram = "claude";
+    };
+  };
 }


### PR DESCRIPTION
## Summary
- Update claude-code overlay from v2.1.38 to v2.1.52
- Notable: adds `claude remote-control` subcommand, shell performance improvements, security fixes

## Test plan
- [ ] `sudo sys test` builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)