### PR TITLE
feat(firefly): Add bootstrap script for full USB install

### DIFF
--- a/modules/home/personal-scripts/scripts/firefly-bootstrap
+++ b/modules/home/personal-scripts/scripts/firefly-bootstrap
@@ -1,0 +1,411 @@
+#!/usr/bin/env bash
+# FireFly Bootstrap - Full USB install: disko → seed secrets → nixos-install
+#
+# Run from a NixOS live USB or an existing NixOS system.
+# Requires: nix with flakes, sudo access, the flake repo, and source secrets.
+#
+# Usage: sudo firefly-bootstrap /dev/sdX [--flake /path/to/flake]
+#
+# What this does:
+#   1. Applies disko partitioning (GPT + LUKS + LVM + Btrfs)
+#   2. Seeds SOPS age keys (system + user)
+#   3. Seeds SSH host keys
+#   4. Creates user home structure under /persist
+#   5. Optionally seeds rclone/rustic configs for firefly-restore
+#   6. Runs nixos-install
+
+set -euo pipefail
+
+# === Configuration ===
+HOSTNAME="FireFly"
+USERNAME="sinh"
+PERSIST="/mnt/persist"
+SYSTEM_PERSIST="$PERSIST/system"
+USER_HOME="$PERSIST/home/$USERNAME"
+
+# Resolve the real user's home (not /root when running under sudo)
+REAL_HOME="${SUDO_USER:+/home/$SUDO_USER}"
+REAL_HOME="${REAL_HOME:-$HOME}"
+
+# Age key for SOPS
+AGE_KEY_SOURCE="${SOPS_AGE_KEY_FILE:-$REAL_HOME/.config/sops/age/keys.txt}"
+
+# === Color output ===
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+info()  { echo -e "${BLUE}[INFO]${NC}  $*"; }
+ok()    { echo -e "${GREEN}[OK]${NC}    $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+err()   { echo -e "${RED}[ERROR]${NC} $*"; }
+step()  { echo -e "\n${GREEN}=== $* ===${NC}"; }
+
+# === Argument parsing ===
+DISK=""
+FLAKE_DIR=""
+SKIP_DISKO=false
+SKIP_INSTALL=false
+DRY_RUN=false
+
+usage() {
+  cat <<EOF
+Usage: sudo $0 /dev/sdX [OPTIONS]
+
+Bootstrap a FireFly NixOS USB from scratch.
+
+Arguments:
+    /dev/sdX              Target disk (e.g., /dev/sda). ALL DATA WILL BE ERASED.
+
+Options:
+    --flake DIR           Path to personal-nixos flake (default: auto-detect)
+    --skip-disko          Skip partitioning (already done)
+    --skip-install        Skip nixos-install (only seed secrets)
+    --dry-run             Show what would be done without executing
+    -h, --help            Show this help
+
+Environment:
+    SOPS_AGE_KEY_FILE     Path to age key file (default: ~/.config/sops/age/keys.txt)
+
+Steps performed:
+    1. Validate prerequisites
+    2. Apply disko (partition, encrypt, format)
+    3. Seed SOPS age keys to /persist/system and /persist/home
+    4. Seed SSH host keys to /persist/system/etc/ssh
+    5. Create user home directory structure
+    6. Copy rclone/rustic configs if available (for firefly-restore)
+    7. Run nixos-install --flake .#FireFly
+EOF
+  exit 0
+}
+
+# Show help without requiring root
+if [[ $# -eq 0 ]]; then
+  usage
+fi
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --flake)     FLAKE_DIR="$2"; shift 2 ;;
+    --skip-disko)   SKIP_DISKO=true; shift ;;
+    --skip-install) SKIP_INSTALL=true; shift ;;
+    --dry-run)      DRY_RUN=true; shift ;;
+    -h|--help)      usage ;;
+    /dev/*)         DISK="$1"; shift ;;
+    *)              err "Unknown argument: $1"; usage ;;
+  esac
+done
+
+# === Validation ===
+step "Validating prerequisites"
+
+if [[ -z "$DISK" ]]; then
+  err "No target disk specified"
+  echo ""
+  usage
+fi
+
+if [[ $EUID -ne 0 ]]; then
+  err "This script must be run as root (sudo)"
+  exit 1
+fi
+
+if [[ ! -b "$DISK" ]]; then
+  err "$DISK is not a block device"
+  exit 1
+fi
+
+# Auto-detect flake directory
+if [[ -z "$FLAKE_DIR" ]]; then
+  FLAKE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+fi
+
+if [[ ! -f "$FLAKE_DIR/flake.nix" ]]; then
+  err "No flake.nix found at $FLAKE_DIR"
+  err "Use --flake to specify the personal-nixos repo path"
+  exit 1
+fi
+
+if [[ ! -d "$FLAKE_DIR/systems/x86_64-linux/$HOSTNAME" ]]; then
+  err "No $HOSTNAME system config found at $FLAKE_DIR/systems/x86_64-linux/$HOSTNAME"
+  exit 1
+fi
+
+if [[ ! -f "$AGE_KEY_SOURCE" ]]; then
+  err "SOPS age key not found: $AGE_KEY_SOURCE"
+  err "Set SOPS_AGE_KEY_FILE or place key at ~/.config/sops/age/keys.txt"
+  exit 1
+fi
+
+ok "Flake: $FLAKE_DIR"
+ok "Disk:  $DISK"
+ok "Age key: $AGE_KEY_SOURCE"
+
+# === Confirm disk operation ===
+echo ""
+warn "This will ERASE ALL DATA on $DISK"
+echo ""
+lsblk "$DISK" 2>/dev/null || true
+echo ""
+read -rp "Type 'yes' to continue: " confirm
+if [[ "$confirm" != "yes" ]]; then
+  info "Aborted."
+  exit 0
+fi
+
+# === Helper: dry-run aware execution ===
+run() {
+  if $DRY_RUN; then
+    info "[dry-run] $*"
+  else
+    "$@"
+  fi
+}
+
+# === Step 1: Disko ===
+if $SKIP_DISKO; then
+  info "Skipping disko (--skip-disko)"
+else
+  step "Step 1: Applying disko partitioning"
+  info "Partitioning $DISK with LUKS + LVM + Btrfs"
+  info "You will be prompted for the LUKS passphrase"
+
+  # Temporarily patch disks.nix to use the actual target disk
+  DISKS_NIX="$FLAKE_DIR/systems/x86_64-linux/$HOSTNAME/disks.nix"
+  CURRENT_DISK=$(grep -oP 'device = "\K[^"]+' "$DISKS_NIX" | head -1)
+
+  if [[ "$CURRENT_DISK" != "$DISK" ]]; then
+    info "Patching disks.nix: $CURRENT_DISK -> $DISK"
+    sed -i "s|device = \"$CURRENT_DISK\"|device = \"$DISK\"|" "$DISKS_NIX"
+    DISK_PATCHED=true
+  fi
+
+  run nix run github:nix-community/disko -- \
+    --mode disko \
+    "$DISKS_NIX"
+
+  # Restore disks.nix if patched
+  if [[ "${DISK_PATCHED:-false}" == "true" ]]; then
+    info "Restoring disks.nix: $DISK -> $CURRENT_DISK"
+    sed -i "s|device = \"$DISK\"|device = \"$CURRENT_DISK\"|" "$DISKS_NIX"
+  fi
+
+  ok "Disko partitioning complete"
+fi
+
+# === Step 2: Verify mounts ===
+step "Step 2: Verifying mount points"
+
+# After disko, filesystems should be mounted at /mnt
+if ! mountpoint -q /mnt 2>/dev/null; then
+  err "/mnt is not mounted. Disko may have failed."
+  err "If you used --skip-disko, mount the filesystems manually first."
+  exit 1
+fi
+
+if ! mountpoint -q /mnt/persist 2>/dev/null; then
+  err "/mnt/persist is not mounted"
+  exit 1
+fi
+
+ok "Root at /mnt, persist at /mnt/persist"
+
+# === Step 3: Seed SOPS age keys ===
+step "Step 3: Seeding SOPS age keys"
+
+# System-level key (used during boot for sops-nix)
+SYSTEM_SOPS_DIR="$SYSTEM_PERSIST/sops/age"
+run mkdir -p "$SYSTEM_SOPS_DIR"
+run cp "$AGE_KEY_SOURCE" "$SYSTEM_SOPS_DIR/keys.txt"
+run chmod 600 "$SYSTEM_SOPS_DIR/keys.txt"
+ok "System age key -> $SYSTEM_SOPS_DIR/keys.txt"
+
+# User-level key (used by sops CLI and home-manager sops)
+USER_SOPS_DIR="$USER_HOME/.config/sops/age"
+run mkdir -p "$USER_SOPS_DIR"
+run cp "$AGE_KEY_SOURCE" "$USER_SOPS_DIR/keys.txt"
+run chmod 600 "$USER_SOPS_DIR/keys.txt"
+ok "User age key -> $USER_SOPS_DIR/keys.txt"
+
+# === Step 4: Seed SSH host keys ===
+step "Step 4: Seeding SSH host keys"
+
+SSH_DIR="$SYSTEM_PERSIST/etc/ssh"
+run mkdir -p "$SSH_DIR"
+
+if [[ -f "$SSH_DIR/ssh_host_ed25519_key" ]]; then
+  info "SSH host keys already exist, skipping generation"
+else
+  run ssh-keygen -t ed25519 -f "$SSH_DIR/ssh_host_ed25519_key" -N "" -C "root@$HOSTNAME"
+  run ssh-keygen -t rsa -b 4096 -f "$SSH_DIR/ssh_host_rsa_key" -N "" -C "root@$HOSTNAME"
+  ok "SSH host keys generated"
+fi
+
+run chmod 600 "$SSH_DIR"/ssh_host_*_key
+run chmod 644 "$SSH_DIR"/ssh_host_*_key.pub
+
+# === Step 5: Create user home structure ===
+step "Step 5: Creating user home directory structure"
+
+# Core directories that need to exist for impermanence bind mounts
+USER_DIRS=(
+  ".ssh"
+  ".gnupg"
+  ".config/sops/age"
+  ".config/gh"
+  ".config/git"
+  ".config/rclone"
+  ".config/rustic"
+  ".config/fish"
+  ".local/share/fish"
+  ".local/share/zoxide"
+  ".config/atuin"
+  ".local/share/atuin"
+  ".cargo"
+  ".local/share/nvim"
+  "git-repos"
+  "Documents"
+  "Pictures"
+  "Videos"
+  "Music"
+  ".zen"
+  ".config/zen"
+  ".config/fcitx5"
+  ".local/share/fcitx5"
+  ".config/Bitwarden"
+  ".config/sinh-x-scripts"
+  ".local/state"
+  ".local/share/applications"
+  ".local/share/icons"
+)
+
+for dir in "${USER_DIRS[@]}"; do
+  run mkdir -p "$USER_HOME/$dir"
+done
+
+ok "User directory structure created at $USER_HOME"
+
+# === Step 6: Seed SSH user keys ===
+step "Step 6: Seeding user SSH keys"
+
+# Look for the current user's SSH keys to copy
+SSH_SOURCE="$REAL_HOME/.ssh"
+
+if [[ -d "$SSH_SOURCE" ]] && ls "$SSH_SOURCE"/id_* &>/dev/null; then
+  info "Copying SSH keys from $SSH_SOURCE"
+  for key in "$SSH_SOURCE"/id_*; do
+    run cp "$key" "$USER_HOME/.ssh/"
+  done
+  # Also copy known_hosts and config if they exist
+  for f in known_hosts config authorized_keys; do
+    if [[ -f "$SSH_SOURCE/$f" ]]; then
+      run cp "$SSH_SOURCE/$f" "$USER_HOME/.ssh/"
+    fi
+  done
+  ok "User SSH keys seeded"
+else
+  warn "No SSH keys found at $SSH_SOURCE"
+  warn "You'll need to manually place SSH keys in $USER_HOME/.ssh/"
+fi
+
+# === Step 7: Seed rclone & rustic configs ===
+step "Step 7: Seeding backup configs (rclone, rustic)"
+
+RCLONE_SOURCE="$REAL_HOME/.config/rclone/rclone.conf"
+RUSTIC_PROFILE="sinh-personal_file"
+RUSTIC_SOURCE="$REAL_HOME/.config/rustic/${RUSTIC_PROFILE}.toml"
+
+if [[ -f "$RCLONE_SOURCE" ]]; then
+  run cp "$RCLONE_SOURCE" "$USER_HOME/.config/rclone/rclone.conf"
+  ok "rclone.conf seeded"
+else
+  warn "rclone.conf not found at $RCLONE_SOURCE"
+  warn "firefly-restore will not work until you provide it"
+fi
+
+if [[ -f "$RUSTIC_SOURCE" ]]; then
+  run cp "$RUSTIC_SOURCE" "$USER_HOME/.config/rustic/${RUSTIC_PROFILE}.toml"
+  ok "rustic profile seeded"
+else
+  warn "rustic profile not found at $RUSTIC_SOURCE"
+  warn "firefly-restore will not work until you provide it"
+fi
+
+# === Step 8: Seed git config ===
+step "Step 8: Seeding git config"
+
+GIT_CONFIG_SOURCE="$REAL_HOME/.config/git"
+if [[ -d "$GIT_CONFIG_SOURCE" ]]; then
+  run cp -r "$GIT_CONFIG_SOURCE"/* "$USER_HOME/.config/git/" 2>/dev/null || true
+  ok "git config seeded"
+else
+  warn "No git config found at $GIT_CONFIG_SOURCE"
+fi
+
+# Also copy gh CLI config for GitHub auth
+GH_SOURCE="$REAL_HOME/.config/gh"
+if [[ -d "$GH_SOURCE" ]] && [[ -f "$GH_SOURCE/hosts.yml" ]]; then
+  run cp "$GH_SOURCE/hosts.yml" "$USER_HOME/.config/gh/"
+  ok "gh CLI config seeded"
+else
+  warn "No gh config found - you'll need to run 'gh auth login' after install"
+fi
+
+# === Step 9: Fix ownership ===
+step "Step 9: Fixing ownership"
+
+# Get the UID/GID that will be used (1000 is typical for first user)
+run chown -R 1000:100 "$USER_HOME"
+ok "Ownership set to 1000:100 (sinh:users)"
+
+# System dirs stay as root
+run chown -R root:root "$SYSTEM_PERSIST"
+ok "System persist ownership set to root"
+
+# === Step 10: nixos-install ===
+if $SKIP_INSTALL; then
+  info "Skipping nixos-install (--skip-install)"
+else
+  step "Step 10: Running nixos-install"
+  info "Installing NixOS with flake: $FLAKE_DIR#$HOSTNAME"
+  info "This will take a while..."
+  echo ""
+
+  run nixos-install \
+    --flake "$FLAKE_DIR#$HOSTNAME" \
+    --no-root-passwd
+
+  ok "nixos-install complete"
+fi
+
+# === Summary ===
+step "Bootstrap Complete"
+echo ""
+info "FireFly USB is ready on $DISK"
+echo ""
+echo "  Disk layout:"
+echo "    ${DISK}1  512MB  ESP (/boot/efi)"
+echo "    ${DISK}2  8GB    swap"
+echo "    ${DISK}3  rest   LUKS → LVM → Btrfs"
+echo ""
+echo "  Btrfs subvolumes:"
+echo "    @root        /          (wiped on every boot)"
+echo "    @nix         /nix       (persistent)"
+echo "    @persist     /persist   (persistent)"
+echo "    @root-blank  (rollback snapshot)"
+echo ""
+echo "  Seeded secrets:"
+echo "    SOPS age key    ✓ system + user"
+echo "    SSH host keys   ✓ ed25519 + rsa"
+[[ -d "$USER_HOME/.ssh" ]] && ls "$USER_HOME/.ssh"/id_* &>/dev/null && echo "    SSH user keys   ✓"
+[[ -f "$USER_HOME/.config/rclone/rclone.conf" ]] && echo "    rclone.conf     ✓"
+[[ -f "$USER_HOME/.config/rustic/${RUSTIC_PROFILE}.toml" ]] && echo "    rustic profile  ✓"
+echo ""
+echo "  Next steps:"
+echo "    1. Boot from the USB"
+echo "    2. Log in as $USERNAME (password from sops)"
+echo "    3. Run 'firefly-restore essential' to pull remaining dotfiles"
+echo "    4. Run 'firefly-restore apps' for app configs"
+echo ""


### PR DESCRIPTION
## Summary
- Adds `firefly-bootstrap` script to personal-scripts module
- Orchestrates full FireFly USB setup: disko → SOPS/SSH key seeding → user home creation → nixos-install
- Supports `--skip-disko`, `--skip-install`, `--dry-run` flags
- Resolves sudo HOME path issue for SOPS age key detection

## Test plan
- [x] Script shows help without requiring root
- [ ] Full run with `sudo firefly-bootstrap /dev/sdX --flake .`
- [ ] Re-run with `--skip-disko` on already-partitioned USB

🤖 Generated with [Claude Code](https://claude.com/claude-code)