### PR TITLE
feat(tailscale): add NixOS module with suspend/resume fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3035,11 +3035,11 @@
         "snowfall-lib": "snowfall-lib_7"
       },
       "locked": {
-        "lastModified": 1770903752,
-        "narHash": "sha256-jgrPa0mq8KoCrtuoOlF+dleMscxVxakZMDL+s7Z5L80=",
+        "lastModified": 1772319070,
+        "narHash": "sha256-5c2Y3xD3DxfovAPwiUJRFMf1/le6sOJCivYoNolPN5I=",
         "owner": "sinh-x",
         "repo": "Neve",
-        "rev": "f09ed15459a2eb914e3a5c3d4179d88669807921",
+        "rev": "a95fe3d7f6d1f62ff5da966fdfa3f448ae92f891",
         "type": "github"
       },
       "original": {

--- a/modules/nixos/tailscale/default.nix
+++ b/modules/nixos/tailscale/default.nix
@@ -1,0 +1,80 @@
+{
+  config,
+  lib,
+  ...
+}:
+with lib;
+let
+  cfg = config.modules.tailscale;
+in
+{
+  options.modules.tailscale = {
+    enable = mkEnableOption "Tailscale VPN with firewall and optional suspend/resume fix";
+
+    authKeySecret = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "SOPS secret path for the Tailscale auth key (e.g. \"tailscale/Drgnfly\")";
+    };
+
+    operator = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "User allowed to operate tailscale without sudo";
+    };
+
+    ssh = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Enable Tailscale SSH";
+    };
+
+    resumeFix = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Restart tailscaled after suspend/resume to avoid 'node not found' loop";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    networking.firewall = {
+      trustedInterfaces = [ "tailscale0" ];
+      allowedUDPPorts = [ config.services.tailscale.port ];
+    };
+
+    sops.secrets.${cfg.authKeySecret} = mkIf (cfg.authKeySecret != null) { };
+
+    services.tailscale = {
+      enable = true;
+      authKeyFile = mkIf (cfg.authKeySecret != null) config.sops.secrets.${cfg.authKeySecret}.path;
+      extraUpFlags = mkIf cfg.ssh [
+        "--ssh"
+        "--reset"
+      ];
+      extraSetFlags = mkIf (cfg.operator != null) [ "--operator=${cfg.operator}" ];
+    };
+
+    # Restart tailscaled after suspend/resume to avoid "node not found" loop
+    # See: https://github.com/tailscale/tailscale/issues — s2idle causes network drop,
+    # tailscaled never re-registers with coordination server
+    systemd.services.tailscale-resume = mkIf cfg.resumeFix {
+      description = "Restart Tailscale after suspend";
+      after = [
+        "suspend.target"
+        "hibernate.target"
+        "hybrid-sleep.target"
+        "suspend-then-hibernate.target"
+      ];
+      wantedBy = [
+        "suspend.target"
+        "hibernate.target"
+        "hybrid-sleep.target"
+        "suspend-then-hibernate.target"
+      ];
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${config.systemd.package}/bin/systemctl restart tailscaled.service";
+      };
+    };
+  };
+}

--- a/systems/x86_64-linux/Drgnfly/default.nix
+++ b/systems/x86_64-linux/Drgnfly/default.nix
@@ -47,6 +47,13 @@
     stubby.enable = true;
     wifi.enable = true;
     wifi.interfaces = [ "wlp9s0" ];
+    tailscale = {
+      enable = true;
+      authKeySecret = "tailscale/Drgnfly";
+      operator = "sinh";
+      ssh = true;
+      resumeFix = true;
+    };
 
     sops.enable = true;
 
@@ -214,20 +221,7 @@
     networkmanager.enable = false;
     firewall = {
       allowedTCPPorts = [ 22 ];
-      trustedInterfaces = [ "tailscale0" ];
-      allowedUDPPorts = [ config.services.tailscale.port ];
     };
-  };
-
-  sops.secrets."tailscale/Drgnfly" = { };
-
-  services.tailscale = {
-    enable = true;
-    authKeyFile = config.sops.secrets."tailscale/Drgnfly".path;
-    extraUpFlags = [
-      "--ssh"
-      "--reset"
-    ];
   };
 
   programs.steam.enable = true;


### PR DESCRIPTION
## Summary
- New `modules.nixos.tailscale` module with options for auth key, operator, SSH, and suspend/resume fix
- Drgnfly config migrated from inline Tailscale to the new module
- Adds systemd oneshot service to restart tailscaled after suspend (fixes "node not found" loop on s2idle resume)
- Adds `--operator=sinh` for sudo-free `tailscale` CLI

## Test plan
- [ ] `sudo sys test` on Drgnfly
- [ ] Suspend and resume laptop — verify `tailscale status` shows online without manual restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)