### PR TITLE
feat(niri): auto-detect external monitor for workspaces

### DIFF
--- a/modules/home/wm/niri/default.nix
+++ b/modules/home/wm/niri/default.nix
@@ -20,48 +20,63 @@ in
         description = "Primary monitor name (e.g., eDP-1). Auto-detected if null.";
         example = "eDP-1";
       };
+      external = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "External monitor connector (e.g., DP-1, HDMI-A-1). When null, ext-* workspaces fall back to primary.";
+        example = "DP-1";
+      };
     };
   };
 
   config = mkIf cfg.enable {
-    home = {
-      packages = with pkgs; [
-        jq
-        socat
-        inotify-tools # For screenshot watcher
-        wl-clipboard # For clipboard operations
-        libnotify # For notifications
-        hyprpicker # Color picker for Wayland
-      ];
+    home =
+      let
+        primaryOutput = if cfg.monitors.primary != null then cfg.monitors.primary else "eDP-1";
+        externalOutput = if cfg.monitors.external != null then cfg.monitors.external else primaryOutput;
+        configTemplate = builtins.readFile ./niri_config/config.kdl;
+        configText =
+          builtins.replaceStrings [ "@PRIMARY_OUTPUT@" "@EXTERNAL_OUTPUT@" ] [ primaryOutput externalOutput ]
+            configTemplate;
+      in
+      {
+        packages = with pkgs; [
+          jq
+          socat
+          inotify-tools # For screenshot watcher
+          wl-clipboard # For clipboard operations
+          libnotify # For notifications
+          hyprpicker # Color picker for Wayland
+        ];
 
-      file = {
-        ".config/niri/config.kdl".source = ./niri_config/config.kdl;
-        ".config/niri/scripts" = {
-          source = ./niri_config/scripts;
-          recursive = true;
-        };
-        ".config/mako" = {
-          source = ./niri_config/mako;
-          recursive = true;
-        };
-        ".config/niri/rofi" = {
-          source = ./niri_config/rofi;
-          recursive = true;
-        };
-        ".config/niri/theme" = {
-          source = ./niri_config/theme;
-          recursive = true;
-        };
-        ".config/niri/wallpapers" = {
-          source = ./niri_config/wallpapers;
-          recursive = true;
-        };
-        ".config/waybar" = {
-          source = ./niri_config/waybar;
-          recursive = true;
+        file = {
+          ".config/niri/config.kdl".text = configText;
+          ".config/niri/scripts" = {
+            source = ./niri_config/scripts;
+            recursive = true;
+          };
+          ".config/mako" = {
+            source = ./niri_config/mako;
+            recursive = true;
+          };
+          ".config/niri/rofi" = {
+            source = ./niri_config/rofi;
+            recursive = true;
+          };
+          ".config/niri/theme" = {
+            source = ./niri_config/theme;
+            recursive = true;
+          };
+          ".config/niri/wallpapers" = {
+            source = ./niri_config/wallpapers;
+            recursive = true;
+          };
+          ".config/waybar" = {
+            source = ./niri_config/waybar;
+            recursive = true;
+          };
         };
       };
-    };
 
     # Screenshot watcher service - copies both image + path to clipboard
     systemd.user.services.screenshot-watcher = {

--- a/modules/home/wm/niri/default.nix
+++ b/modules/home/wm/niri/default.nix
@@ -20,12 +20,6 @@ in
         description = "Primary monitor name (e.g., eDP-1). Auto-detected if null.";
         example = "eDP-1";
       };
-      external = mkOption {
-        type = types.nullOr types.str;
-        default = null;
-        description = "External monitor connector (e.g., DP-1, HDMI-A-1). When null, ext-* workspaces fall back to primary.";
-        example = "DP-1";
-      };
     };
   };
 
@@ -33,11 +27,11 @@ in
     home =
       let
         primaryOutput = if cfg.monitors.primary != null then cfg.monitors.primary else "eDP-1";
-        externalOutput = if cfg.monitors.external != null then cfg.monitors.external else primaryOutput;
         configTemplate = builtins.readFile ./niri_config/config.kdl;
-        configText =
-          builtins.replaceStrings [ "@PRIMARY_OUTPUT@" "@EXTERNAL_OUTPUT@" ] [ primaryOutput externalOutput ]
-            configTemplate;
+        configText = builtins.replaceStrings [ "@PRIMARY_OUTPUT@" ] [ primaryOutput ] configTemplate;
+        workspaceMonitorsScript = builtins.replaceStrings [ "@PRIMARY_OUTPUT@" ] [ primaryOutput ] (
+          builtins.readFile ./niri_config/scripts/workspace_monitors
+        );
       in
       {
         packages = with pkgs; [
@@ -54,6 +48,10 @@ in
           ".config/niri/scripts" = {
             source = ./niri_config/scripts;
             recursive = true;
+          };
+          ".config/niri/scripts/workspace_monitors" = {
+            text = workspaceMonitorsScript;
+            executable = true;
           };
           ".config/mako" = {
             source = ./niri_config/mako;

--- a/modules/home/wm/niri/niri_config/config.kdl
+++ b/modules/home/wm/niri/niri_config/config.kdl
@@ -60,16 +60,11 @@ workspace "email" {
     open-on-output "@PRIMARY_OUTPUT@"
 }
 
-// External monitor (ext-) - external display
-workspace "ext-term" {
-    open-on-output "@EXTERNAL_OUTPUT@"
-}
-workspace "ext-browser" {
-    open-on-output "@EXTERNAL_OUTPUT@"
-}
-workspace "ext-code" {
-    open-on-output "@EXTERNAL_OUTPUT@"
-}
+// External monitor (ext-) - auto-assigned to external display at startup
+// via workspace_monitors script (no hardcoded output binding)
+workspace "ext-term" {}
+workspace "ext-browser" {}
+workspace "ext-code" {}
 
 // Layout configuration
 layout {

--- a/modules/home/wm/niri/niri_config/config.kdl
+++ b/modules/home/wm/niri/niri_config/config.kdl
@@ -43,32 +43,32 @@ output "MaxCom Technical Inc 0x1B1A 0x20230808" {
 
 // Named workspaces (always exist, even when empty)
 // Using connector names for portability - workspaces follow the port, not the specific monitor
-// Laptop monitor (main-) - eDP-1 is the built-in display
+// Laptop monitor (main-) - primary display
 workspace "main-term" {
-    open-on-output "eDP-1"
+    open-on-output "@PRIMARY_OUTPUT@"
 }
 workspace "main-browser" {
-    open-on-output "eDP-1"
+    open-on-output "@PRIMARY_OUTPUT@"
 }
 workspace "main-code" {
-    open-on-output "eDP-1"
+    open-on-output "@PRIMARY_OUTPUT@"
 }
 workspace "chat" {
-    open-on-output "eDP-1"
+    open-on-output "@PRIMARY_OUTPUT@"
 }
 workspace "email" {
-    open-on-output "eDP-1"
+    open-on-output "@PRIMARY_OUTPUT@"
 }
 
-// External monitor (ext-) - DP-6 for external monitor
+// External monitor (ext-) - external display
 workspace "ext-term" {
-    open-on-output "DP-6"
+    open-on-output "@EXTERNAL_OUTPUT@"
 }
 workspace "ext-browser" {
-    open-on-output "DP-6"
+    open-on-output "@EXTERNAL_OUTPUT@"
 }
 workspace "ext-code" {
-    open-on-output "DP-6"
+    open-on-output "@EXTERNAL_OUTPUT@"
 }
 
 // Layout configuration

--- a/modules/home/wm/niri/niri_config/scripts/startup_apps
+++ b/modules/home/wm/niri/niri_config/scripts/startup_apps
@@ -10,6 +10,9 @@ while ! niri msg --json outputs &>/dev/null 2>&1; do
     sleep 0.2
 done
 
+# Phase 0: Move ext-* workspaces to external monitor (if connected)
+~/.config/niri/scripts/workspace_monitors
+
 # Phase 1: Chat & productivity apps (window rules -> chat/email workspace)
 anytype &
 discord &

--- a/modules/home/wm/niri/niri_config/scripts/workspace_monitors
+++ b/modules/home/wm/niri/niri_config/scripts/workspace_monitors
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+## Auto-assign ext-* workspaces to the first detected external monitor.
+## If no external monitor is found, workspaces stay on primary.
+
+PRIMARY="@PRIMARY_OUTPUT@"
+EXT_WORKSPACES=("ext-term" "ext-browser" "ext-code")
+
+# Find external monitor (any connected output that isn't primary)
+EXTERNAL=$(niri msg --json outputs | jq -r 'keys[]' | grep -v "^${PRIMARY}$" | head -1)
+
+if [[ -z "$EXTERNAL" ]]; then
+    exit 0
+fi
+
+for ws in "${EXT_WORKSPACES[@]}"; do
+    niri msg action move-workspace-to-monitor --reference "$ws" "$EXTERNAL" 2>/dev/null
+done


### PR DESCRIPTION
## Summary
- Add dynamic external monitor detection for ext-* workspaces using niri IPC
- Replace hardcoded output bindings with a startup script that finds any non-primary monitor
- Remove `monitors.external` option (no longer needed)

## Test plan
- [x] Verified ext-* workspaces auto-move to DP-5 at runtime
- [x] Script falls back gracefully when no external monitor connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)