### PR TITLE
feat: add zeroclaw with daemon autostart

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -175,6 +175,28 @@
         "type": "github"
       }
     },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "sinh-x-zeroclaw",
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1771398736,
+        "narHash": "sha256-pjV3C7VJHN0o2SvE3O6xiwraLt7bnlWIF3o7Q0BC1jk=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "0f608091816de13d92e1f4058b501028b782dddd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "firefox-addons": {
       "inputs": {
         "nixpkgs": [
@@ -826,7 +848,7 @@
     },
     "flake-utils-plus_12": {
       "inputs": {
-        "flake-utils": "flake-utils_16"
+        "flake-utils": "flake-utils_17"
       },
       "locked": {
         "lastModified": 1715533576,
@@ -845,7 +867,7 @@
     },
     "flake-utils-plus_13": {
       "inputs": {
-        "flake-utils": "flake-utils_17"
+        "flake-utils": "flake-utils_18"
       },
       "locked": {
         "lastModified": 1715533576,
@@ -1117,6 +1139,24 @@
       }
     },
     "flake-utils_16": {
+      "inputs": {
+        "systems": "systems_13"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_17": {
       "locked": {
         "lastModified": 1644229661,
         "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
@@ -1131,9 +1171,9 @@
         "type": "github"
       }
     },
-    "flake-utils_17": {
+    "flake-utils_18": {
       "inputs": {
-        "systems": "systems_13"
+        "systems": "systems_14"
       },
       "locked": {
         "lastModified": 1694529238,
@@ -1149,9 +1189,9 @@
         "type": "github"
       }
     },
-    "flake-utils_18": {
+    "flake-utils_19": {
       "inputs": {
-        "systems": "systems_15"
+        "systems": "systems_16"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -2426,6 +2466,21 @@
     },
     "nixpkgs_16": {
       "locked": {
+        "lastModified": 1771369470,
+        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0182a361324364ae3f436a63005877674cf45efb",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_17": {
+      "locked": {
         "lastModified": 1769461804,
         "narHash": "sha256-msG8SU5WsBUfVVa/9RPLaymvi5bI8edTavbIq3vRlhI=",
         "owner": "nixos",
@@ -2440,7 +2495,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_17": {
+    "nixpkgs_18": {
       "locked": {
         "lastModified": 1765934234,
         "narHash": "sha256-pJjWUzNnjbIAMIc5gRFUuKCDQ9S1cuh3b2hKgA7Mc4A=",
@@ -2932,12 +2987,30 @@
         "sinh-x-pomodoro": "sinh-x-pomodoro",
         "sinh-x-super-productivity": "sinh-x-super-productivity",
         "sinh-x-wallpaper": "sinh-x-wallpaper",
+        "sinh-x-zeroclaw": "sinh-x-zeroclaw",
         "snowfall-flake": "snowfall-flake_6",
         "snowfall-lib": "snowfall-lib_13",
         "sops-nix": "sops-nix",
-        "systems": "systems_14",
+        "systems": "systems_15",
         "zen-browser": "zen-browser",
         "zjstatus": "zjstatus"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1771353660,
+        "narHash": "sha256-yp1y55kXgaa08g/gR3CNiUdkg1JRjPYfkKtEIRNE6S8=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "09f2d468eda25a5f06ae70046357c70ae5cd77c7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "rust-overlay": {
@@ -3111,6 +3184,27 @@
       "original": {
         "owner": "sinh-x",
         "repo": "sinh-x-wallpaper",
+        "type": "github"
+      }
+    },
+    "sinh-x-zeroclaw": {
+      "inputs": {
+        "fenix": "fenix",
+        "flake-utils": "flake-utils_16",
+        "nixpkgs": "nixpkgs_16"
+      },
+      "locked": {
+        "lastModified": 1772504754,
+        "narHash": "sha256-vBGMu19xiUXjZgkRDAbtrA2r7tQYAud55Pl8bMrNfjg=",
+        "owner": "sinh-x",
+        "repo": "zeroclaw",
+        "rev": "cd057859817319bf4ccc3287ebcccde4967096c5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sinh-x",
+        "ref": "sinh-x",
+        "repo": "zeroclaw",
         "type": "github"
       }
     },
@@ -3658,6 +3752,21 @@
     },
     "systems_14": {
       "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_15": {
+      "locked": {
         "lastModified": 1689347949,
         "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
         "owner": "nix-systems",
@@ -3671,7 +3780,7 @@
         "type": "github"
       }
     },
-    "systems_15": {
+    "systems_16": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -3916,7 +4025,7 @@
     "zen-browser": {
       "inputs": {
         "home-manager": "home-manager_6",
-        "nixpkgs": "nixpkgs_16"
+        "nixpkgs": "nixpkgs_17"
       },
       "locked": {
         "lastModified": 1770568363,
@@ -3935,8 +4044,8 @@
     "zjstatus": {
       "inputs": {
         "crane": "crane",
-        "flake-utils": "flake-utils_18",
-        "nixpkgs": "nixpkgs_17",
+        "flake-utils": "flake-utils_19",
+        "nixpkgs": "nixpkgs_18",
         "rust-overlay": "rust-overlay"
       },
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -71,6 +71,10 @@
       url = "github:sinh-x/ip_update";
       # url = "/home/sinh/git-repos/sinh-x/ip_update";
     };
+    sinh-x-zeroclaw = {
+      url = "github:sinh-x/zeroclaw/sinh-x";
+      # url = "/home/sinh/git-repos/sinh-x/tools/zeroclaw";
+    };
     sinh-x-avodah = {
       url = "github:sinh-x/avodah/v0.3.0-beta.3";
       # url = "/home/sinh/git-repos/sinh-x/tools/avodah";

--- a/modules/home/apps/sinh-x/default.nix
+++ b/modules/home/apps/sinh-x/default.nix
@@ -28,5 +28,21 @@ in
       avo
       sinh-x-zeroclaw
     ];
+
+    systemd.user.services.zeroclaw = {
+      Unit = {
+        Description = "ZeroClaw daemon";
+        After = [ "default.target" ];
+      };
+      Service = {
+        Type = "simple";
+        ExecStart = "${pkgs.sinh-x-zeroclaw}/bin/zeroclaw daemon";
+        Restart = "on-failure";
+        RestartSec = 10;
+      };
+      Install = {
+        WantedBy = [ "default.target" ];
+      };
+    };
   };
 }

--- a/modules/home/apps/sinh-x/default.nix
+++ b/modules/home/apps/sinh-x/default.nix
@@ -26,6 +26,7 @@ in
       #sinh-x-gitstatus
       sinh-x-ip_updater
       avo
+      sinh-x-zeroclaw
     ];
   };
 }

--- a/overlays/sinh-x/default.nix
+++ b/overlays/sinh-x/default.nix
@@ -21,6 +21,8 @@ _final: prev: {
 
   inherit (inputs.sinh-x-avodah.packages.${prev.stdenv.hostPlatform.system}) avo;
 
+  inherit (inputs.sinh-x-zeroclaw.packages.${prev.stdenv.hostPlatform.system}) sinh-x-zeroclaw;
+
   nixvim = inputs.sinh-x-nixvim.packages.${prev.stdenv.hostPlatform.system}.nvim;
   zjstatus = inputs.zjstatus.packages.${prev.stdenv.hostPlatform.system}.default;
 


### PR DESCRIPTION
## Summary
- Add sinh-x-zeroclaw as flake input, overlay, and home package
- Add systemd user service for `zeroclaw daemon` autostart on login

## Test plan
- [x] Dry-run build passes
- [ ] `sudo sys test` builds and activates
- [ ] `systemctl --user status zeroclaw` shows active after login

🤖 Generated with [Claude Code](https://claude.com/claude-code)