### PR TITLE
fix: resolve nixpkgs deprecation warnings

### DIFF
--- a/checks/pre-commit-hooks/default.nix
+++ b/checks/pre-commit-hooks/default.nix
@@ -9,7 +9,7 @@ let
   inherit (inputs) pre-commit-hooks-nix;
   inherit (lib) getExe;
 in
-pre-commit-hooks-nix.lib.${pkgs.system}.run {
+pre-commit-hooks-nix.lib.${pkgs.stdenv.hostPlatform.system}.run {
   src = ./.;
   hooks =
     let

--- a/modules/home/apps/web/zen-browser/default.nix
+++ b/modules/home/apps/web/zen-browser/default.nix
@@ -15,6 +15,7 @@ in
     programs.zen-browser = {
       # This enables the configuration and usually installs the package
       enable = true;
+      suppressXdgMigrationWarning = true;
 
       # 3. ADD YOUR CONFIGURATION OPTIONS
       policies = {

--- a/modules/nixos/nix_ld/default.nix
+++ b/modules/nixos/nix_ld/default.nix
@@ -54,20 +54,20 @@ in
         stdenv.cc.cc
         systemd
         vulkan-loader
-        xorg.libX11
-        xorg.libXScrnSaver
-        xorg.libXcomposite
-        xorg.libXcursor
-        xorg.libXdamage
-        xorg.libXext
-        xorg.libXfixes
-        xorg.libXi
-        xorg.libXrandr
-        xorg.libXrender
-        xorg.libXtst
-        xorg.libxcb
-        xorg.libxkbfile
-        xorg.libxshmfence
+        libx11
+        libxscrnsaver
+        libxcomposite
+        libxcursor
+        libxdamage
+        libxext
+        libxfixes
+        libxi
+        libxrandr
+        libxrender
+        libxtst
+        libxcb
+        libxkbfile
+        libxshmfence
         zlib
 
         gcc

--- a/overlays/zjstatus/default.nix
+++ b/overlays/zjstatus/default.nix
@@ -5,5 +5,5 @@
 _final: prev: {
   # For example, to pull a package from unstable NixPkgs make sure you have the
   # input `unstable = "github:nixos/nixpkgs/nixos-unstable"` in your flake.
-  zjstatus = inputs.zjstatus.packages.${prev.system}.default;
+  zjstatus = inputs.zjstatus.packages.${prev.stdenv.hostPlatform.system}.default;
 }

--- a/packages/positron-sinh/default.nix
+++ b/packages/positron-sinh/default.nix
@@ -17,7 +17,10 @@
   openssl,
   patchelf,
   stdenv,
-  xorg,
+  libx11,
+  libxcomposite,
+  libxdamage,
+  libxkbfile,
 }:
 let
   pname = "positron-sinh";
@@ -45,10 +48,10 @@ stdenv.mkDerivation {
     nss
     openssl
     stdenv.cc.cc
-    xorg.libX11
-    xorg.libXcomposite
-    xorg.libXdamage
-    xorg.libxkbfile
+    libx11
+    libxcomposite
+    libxdamage
+    libxkbfile
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     blas


### PR DESCRIPTION
## Summary
- Replace deprecated `pkgs.system` / `prev.system` with `stdenv.hostPlatform.system` in checks and zjstatus overlay
- Rename deprecated `xorg.*` package references to new top-level names in nix-ld and positron-sinh
- Suppress zen-browser XDG migration warning

## Test plan
- [x] `nix eval` confirms reduced warnings (remaining `fold` and 1x `system` from upstream deps)
- [ ] `sudo sys test` to verify system builds and activates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)