### PR TITLE
fix(drgnfly): disable libvirtd credential encryption on impermanence

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3178,11 +3178,11 @@
         "nixpkgs": "nixpkgs_12"
       },
       "locked": {
-        "lastModified": 1773312417,
-        "narHash": "sha256-ZxEr1yRH7t+lytVETCU2AAK/oq+N9s16juHrDK4XCiU=",
+        "lastModified": 1773337841,
+        "narHash": "sha256-KyARTckGTIrCz4PixZROrXhxFP+lscceshgu/RfALCI=",
         "ref": "refs/heads/main",
-        "rev": "42e11107fc617cc1f780b88a8b303a9ae70de752",
-        "revCount": 35,
+        "rev": "87a6624d9e9a14cdb60914db56ac36919b698b8a",
+        "revCount": 38,
         "type": "git",
         "url": "ssh://git@github.com/sinh-x/personal-assistant"
       },

--- a/modules/nixos/impermanence/default.nix
+++ b/modules/nixos/impermanence/default.nix
@@ -53,6 +53,7 @@ in
       files = [
         "/etc/machine-id"
         "/etc/adjtime"
+        "/var/lib/systemd/credential.secret"
       ];
     };
 

--- a/modules/nixos/impermanence/default.nix
+++ b/modules/nixos/impermanence/default.nix
@@ -53,7 +53,6 @@ in
       files = [
         "/etc/machine-id"
         "/etc/adjtime"
-        "/var/lib/systemd/credential.secret"
       ];
     };
 

--- a/systems/x86_64-linux/Drgnfly/default.nix
+++ b/systems/x86_64-linux/Drgnfly/default.nix
@@ -230,6 +230,11 @@
   virtualisation.libvirtd.enable = true;
   programs.virt-manager.enable = true;
 
+  # libvirt 12.1.0 uses LoadCredentialEncrypted which requires systemd's
+  # machine credential key — unavailable on impermanence. Clear it so libvirtd
+  # manages its secrets key without systemd credential encryption.
+  systemd.services.libvirtd.serviceConfig.LoadCredentialEncrypted = lib.mkForce "";
+
   # Add libvirtd group for this system
   users.users.sinh.extraGroups = [ "libvirtd" ];
 


### PR DESCRIPTION
## Summary
- libvirt 12.1.0 added `LoadCredentialEncrypted` to its service unit, requiring systemd's machine credential key
- On impermanence systems, this key doesn't persist across boots, causing `libvirtd` to fail with `status=243/CREDENTIALS`
- Override `LoadCredentialEncrypted = ""` in Drgnfly's config to clear the directive — libvirtd manages its secrets key without systemd credential encryption
- Reverted an earlier attempt to persist the credential key via impermanence (caused symlink loop)

## Test plan
- [x] `sudo sys rebuild` applied successfully on Drgnfly
- [x] `sudo systemctl restart libvirtd` started successfully after removing old encrypted key

🤖 Generated with [Claude Code](https://claude.com/claude-code)