### PR TITLE
feat(tailscale): add exit node support, enable on Drgnfly

### DIFF
--- a/modules/nixos/tailscale/default.nix
+++ b/modules/nixos/tailscale/default.nix
@@ -34,6 +34,12 @@ in
       default = false;
       description = "Restart tailscaled after suspend/resume to avoid 'node not found' loop";
     };
+
+    exitNode = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Advertise this machine as a Tailscale exit node";
+    };
   };
 
   config = mkIf cfg.enable {
@@ -47,10 +53,13 @@ in
     services.tailscale = {
       enable = true;
       authKeyFile = mkIf (cfg.authKeySecret != null) config.sops.secrets.${cfg.authKeySecret}.path;
-      extraUpFlags = mkIf cfg.ssh [
-        "--ssh"
-        "--reset"
-      ];
+      useRoutingFeatures = mkIf cfg.exitNode "server";
+      extraUpFlags =
+        lib.optionals cfg.ssh [
+          "--ssh"
+          "--reset"
+        ]
+        ++ lib.optionals cfg.exitNode [ "--advertise-exit-node" ];
       extraSetFlags = mkIf (cfg.operator != null) [ "--operator=${cfg.operator}" ];
     };
 

--- a/systems/x86_64-linux/Drgnfly/default.nix
+++ b/systems/x86_64-linux/Drgnfly/default.nix
@@ -53,6 +53,7 @@
       operator = "sinh";
       ssh = true;
       resumeFix = true;
+      exitNode = true;
     };
 
     sops.enable = true;


### PR DESCRIPTION
## Summary
- Add `exitNode` option to tailscale module — sets `useRoutingFeatures = "server"` and advertises `--advertise-exit-node`
- Enable exit node on Drgnfly (laptop)

## Post-deploy
Approve in Tailscale admin console: Machines → Drgnfly → Edit route settings → enable **Use as exit node**

🤖 Generated with [Claude Code](https://claude.com/claude-code)