### PR TITLE
fix(firefly): SSH only via Tailscale — remove public port 22

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3178,11 +3178,11 @@
         "nixpkgs": "nixpkgs_12"
       },
       "locked": {
-        "lastModified": 1773558447,
-        "narHash": "sha256-v/0phwLng/Ca8gw6wiO8KdHCu3S8WuhyfUdXvLDF6ME=",
+        "lastModified": 1773576737,
+        "narHash": "sha256-9TLFmbC5FCl3bEUNDLe7Ke5b6cwBsVoYXX3ES4fsMjM=",
         "ref": "refs/heads/main",
-        "rev": "f4fe5106a92bcb65ea79b0bdc1d006a65a359e50",
-        "revCount": 69,
+        "rev": "1148f5c761ec3bca534c18f6371e0a6a2a37204d",
+        "revCount": 77,
         "type": "git",
         "url": "ssh://git@github.com/sinh-x/personal-assistant"
       },

--- a/flake.lock
+++ b/flake.lock
@@ -3091,11 +3091,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1773505178,
-        "narHash": "sha256-xJ9Qs6VGvd8rPWu7AWU6n3fXhoCeHYDmp7ODiucBke4=",
+        "lastModified": 1773558199,
+        "narHash": "sha256-+secZLFd/EOkE51NvK4+Yz9kMH1G0HxSwRpYQGR7QVc=",
         "owner": "sinh-x",
         "repo": "avodah",
-        "rev": "72ae5004c694a5925ad8c4bfb8843d6b3f79777b",
+        "rev": "6666b4b2c328299629bd5d5cddc1fa678318e54a",
         "type": "github"
       },
       "original": {
@@ -3178,11 +3178,11 @@
         "nixpkgs": "nixpkgs_12"
       },
       "locked": {
-        "lastModified": 1773501323,
-        "narHash": "sha256-9i39W6oS6QjHDBPz/My8b9p03Cna7Kr1PJpDlDJSP/o=",
+        "lastModified": 1773558447,
+        "narHash": "sha256-v/0phwLng/Ca8gw6wiO8KdHCu3S8WuhyfUdXvLDF6ME=",
         "ref": "refs/heads/main",
-        "rev": "cd440ff16ddaec2c5b0387596a1b3c7828edfe42",
-        "revCount": 65,
+        "rev": "f4fe5106a92bcb65ea79b0bdc1d006a65a359e50",
+        "revCount": 69,
         "type": "git",
         "url": "ssh://git@github.com/sinh-x/personal-assistant"
       },

--- a/systems/x86_64-linux/FireFly/default.nix
+++ b/systems/x86_64-linux/FireFly/default.nix
@@ -150,7 +150,6 @@
   networking = {
     hostName = "FireFly";
     networkmanager.enable = false;
-    firewall.allowedTCPPorts = [ 22 ];
   };
 
   services = {


### PR DESCRIPTION
## Summary
- Removes `firewall.allowedTCPPorts = [ 22 ]` from FireFly networking config
- Port 22 was unnecessarily exposed on all interfaces (LAN/internet)
- Tailscale SSH works through the trusted `tailscale0` interface, which already has all ports open via `trustedInterfaces`
- SSH is now only accessible via Tailscale — no keys required, no public exposure

## Test plan
- [ ] Rebuild FireFly: `sudo sys rebuild`
- [ ] Verify `ssh sinh@firefly` works via Tailscale IP/MagicDNS
- [ ] Verify direct LAN SSH (`ssh sinh@<local-ip>`) is refused

🤖 Generated with [Claude Code](https://claude.com/claude-code)