### PR TITLE
fix(firefly): correct SOPS secret key case tailscale/Firefly

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3091,11 +3091,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1773558199,
-        "narHash": "sha256-+secZLFd/EOkE51NvK4+Yz9kMH1G0HxSwRpYQGR7QVc=",
+        "lastModified": 1773589988,
+        "narHash": "sha256-8Um1VXhl0omtwDWDnIPY5XPvl39CLzYDeh6Hs55T/oI=",
         "owner": "sinh-x",
         "repo": "avodah",
-        "rev": "6666b4b2c328299629bd5d5cddc1fa678318e54a",
+        "rev": "fa2cc4a2c7bd75729e34f5151205061209d7d3a4",
         "type": "github"
       },
       "original": {
@@ -3178,11 +3178,11 @@
         "nixpkgs": "nixpkgs_12"
       },
       "locked": {
-        "lastModified": 1773576737,
-        "narHash": "sha256-9TLFmbC5FCl3bEUNDLe7Ke5b6cwBsVoYXX3ES4fsMjM=",
+        "lastModified": 1773590861,
+        "narHash": "sha256-AWu2bIVQ4eJTv7w/y7wbEBz+bRXIDrATMJhJIYoI5XA=",
         "ref": "refs/heads/main",
-        "rev": "1148f5c761ec3bca534c18f6371e0a6a2a37204d",
-        "revCount": 77,
+        "rev": "a1a78cc4dbb4724df43626e92a70fb5229c3f1e1",
+        "revCount": 79,
         "type": "git",
         "url": "ssh://git@github.com/sinh-x/personal-assistant"
       },

--- a/secrets/secrets.yaml
+++ b/secrets/secrets.yaml
@@ -21,7 +21,7 @@ sops:
             ZnkxT294bUlyeUVKRlFMZlROMTF2MGMKPR3mY9Cm+PtS9NYdMV6ZuPkMcP+8qM5m
             wlfKiOBg2YuyrfjoB7U/YIXeEfO5z72lNaGSWRrm7Bel8uvLwrt8oQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-13T11:50:11Z"
-    mac: ENC[AES256_GCM,data:CMiDEubwnsex7W4em+Ad0qyLlPjP8PnmELbp6aU5un0ILTIgXr/8kRDcu61dqnq0Fx3dbXDL6TWUUO+WeLvS8Sss70fHhr/Yq4AOfyu0ZDIpKoyDKD741l40GoRn+JStolzeO1Vmm4JdAwxG4tyjr2eXy0kodJQVR/l5RJUHs7I=,iv:s4lMU2tz3d4Lsjz9mi3UN2oHqPqUynjO2tENpp/MfVE=,tag:yUuP88DLZiCZ+uEQvsqP1w==,type:str]
+    lastmodified: "2026-03-15T16:04:04Z"
+    mac: ENC[AES256_GCM,data:UAAgjXU2X72WX23jkaI+X9+xKkN79D4ZrboPqCXg4HXqkffXKKOQQVBy4sDv1sDshRcxZMZU6znqGdHRYGrTMrv3n4s1xtb9PgViOBFL0o6FbZ62Dm3LYNiuRfPF7Wl98rULAmgkQUC1OWIxNusj5buXnKschqKc0lx0dvXdno0=,iv:DtZisR1hYJXHNaox3Wf3Ewcu8NYlAPVPa60wEcuDNa4=,tag:fpAbwSj9Z9L1YZO65P5wYw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.1

--- a/systems/x86_64-linux/FireFly/default.nix
+++ b/systems/x86_64-linux/FireFly/default.nix
@@ -33,7 +33,7 @@
     wifi.enable = true;
     tailscale = {
       enable = true;
-      authKeySecret = "tailscale/FireFly";
+      authKeySecret = "tailscale/Firefly";
       operator = "sinh";
       ssh = true;
       resumeFix = true;


### PR DESCRIPTION
## Summary
- Fixes typo in SOPS secret path: `tailscale/FireFly` → `tailscale/Firefly`
- Was causing build failure: `the key 'tailscale/FireFly' cannot be found`

## Test plan
- [ ] Rebuild FireFly: `sudo sys rebuild`
- [ ] Verify Tailscale SSH works: `ssh sinh@firefly`

🤖 Generated with [Claude Code](https://claude.com/claude-code)