### PR TITLE
feat(nixos): add thermal-printer module for Y41BT USB printer

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3128,8 +3128,8 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1774517369,
-        "narHash": "sha256-4ZInJs23hfriR0hhv/uDGC25UrZknjz755qmBq+Ya2o=",
+        "lastModified": 1774596860,
+        "narHash": "sha256-20SYPB0QnTqIxzMfO91NmeQe/IcytRfGmmCKZOTr6kI=",
         "path": "/home/sinh/git-repos/sinh-x/tools/avodah",
         "type": "path"
       },
@@ -3211,7 +3211,7 @@
         "nixpkgs": "nixpkgs_12"
       },
       "locked": {
-        "lastModified": 1774531060,
+        "lastModified": 1774566658,
         "narHash": "sha256-4WkbD1nlu93rWqOcvJxsKClyD44M/xxN7sBc90S82CA=",
         "path": "/home/sinh/git-repos/sinh-x/tools/personal-assistant",
         "type": "path"

--- a/flake.lock
+++ b/flake.lock
@@ -3128,8 +3128,8 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1774185700,
-        "narHash": "sha256-9CBvB/NVYT83fTR21NB9BzjefOtSiaUHSY3E1DX4g2o=",
+        "lastModified": 1774517369,
+        "narHash": "sha256-4ZInJs23hfriR0hhv/uDGC25UrZknjz755qmBq+Ya2o=",
         "path": "/home/sinh/git-repos/sinh-x/tools/avodah",
         "type": "path"
       },
@@ -3211,8 +3211,8 @@
         "nixpkgs": "nixpkgs_12"
       },
       "locked": {
-        "lastModified": 1774489493,
-        "narHash": "sha256-o11VIgCNsOApAK8T2ud0GW6h8hPAeq+GtCAOy7Yd7hQ=",
+        "lastModified": 1774531060,
+        "narHash": "sha256-4WkbD1nlu93rWqOcvJxsKClyD44M/xxN7sBc90S82CA=",
         "path": "/home/sinh/git-repos/sinh-x/tools/personal-assistant",
         "type": "path"
       },

--- a/modules/nixos/thermal-printer/default.nix
+++ b/modules/nixos/thermal-printer/default.nix
@@ -1,0 +1,30 @@
+{
+  config,
+  lib,
+  ...
+}:
+with lib;
+let
+  cfg = config.modules.thermal-printer;
+in
+{
+  options.modules.thermal-printer = {
+    enable = mkEnableOption "Y41BT USB thermal printer support";
+  };
+
+  config = mkIf cfg.enable {
+    # Load usblp kernel module on boot
+    boot.kernelModules = [ "usblp" ];
+
+    # Udev rule for Y41BT USB thermal printer (VID: 5958, PID: 0041)
+    # - Sets MODE 0666 for all-user read/write access
+    # - Creates stable symlink /dev/thermal-printer
+    # Note: usblp claims the device from libusb, which inherently prevents
+    # CUPS from accessing it. This is the desired behavior for direct USB access.
+    services.udev.extraRules = ''
+      # Y41BT USB Thermal Printer (VID: 5958, PID: 0041)
+      # Set world-readable/writable permissions and create stable symlink
+      SUBSYSTEM=="usbmisc", ATTRS{idVendor}=="5958", ATTRS{idProduct}=="0041", MODE:="0666", SYMLINK+="thermal-printer"
+    '';
+  };
+}

--- a/systems/x86_64-linux/Drgnfly/default.nix
+++ b/systems/x86_64-linux/Drgnfly/default.nix
@@ -42,6 +42,7 @@
 
     docker.enable = true;
     ollama.enable = true;
+    thermal-printer.enable = true;
 
     # network
     stubby.enable = true;

--- a/systems/x86_64-linux/Drgnfly/default.nix
+++ b/systems/x86_64-linux/Drgnfly/default.nix
@@ -197,6 +197,7 @@
     ntfs3g
     compsize # Check btrfs compression ratios
     cargo-binstall # Install pre-built Rust binaries from GitHub (e.g., cargo binstall gurk-rs)
+    uv
 
     usbutils # lsusb
     smartmontools # smartctl

--- a/systems/x86_64-linux/Lily/default.nix
+++ b/systems/x86_64-linux/Lily/default.nix
@@ -84,6 +84,7 @@
     };
 
     docker.enable = false;
+    thermal-printer.enable = true;
 
     # network
     stubby.enable = true;


### PR DESCRIPTION
## Summary
- New NixOS module `modules/nixos/thermal-printer/` for Y41BT USB thermal printer support
- Adds `usblp` kernel module auto-load on boot
- Creates udev rule (VID 5958, PID 0041) with MODE 0666 and stable `/dev/thermal-printer` symlink
- Enabled on both Drgnfly and Lily systems
- CUPS non-interference documented (usblp claims device from libusb)

## Ticket
DG-045

## Test plan
- [ ] `nix build .#nixosConfigurations.Drgnfly.config.system.build.toplevel` passes
- [ ] `nix build .#nixosConfigurations.Lily.config.system.build.toplevel` passes
- [ ] After `sudo sys rebuild`: verify `lsmod | grep usblp` shows module loaded
- [ ] Verify `/dev/thermal-printer` symlink exists when Y41BT is connected
- [ ] Verify all users can write to `/dev/thermal-printer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)