### PR TITLE
NX-011: Rename swww to awww after nixpkgs rename

### DIFF
--- a/modules/home/wm/niri/niri_config/config.kdl
+++ b/modules/home/wm/niri/niri_config/config.kdl
@@ -361,7 +361,7 @@ binds {
 // Startup applications
 spawn-at-startup "bash" "-c" "~/.config/niri/scripts/statusbar"
 spawn-at-startup "mako"
-spawn-at-startup "swww-daemon"
+spawn-at-startup "awww-daemon"
 spawn-at-startup "bash" "-c" "sleep 1 && ~/.config/niri/scripts/wallpaper --default"
 spawn-at-startup "wl-paste" "--type" "text" "--watch" "cliphist" "store"
 spawn-at-startup "wl-paste" "--type" "image" "--watch" "cliphist" "store"

--- a/modules/home/wm/niri/niri_config/scripts/wallpaper
+++ b/modules/home/wm/niri/niri_config/scripts/wallpaper
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-## Set Wallpaper in Niri using swww
+## Set Wallpaper in Niri using awww
 
 WALLPAPER_DIR="$HOME/Pictures/Wallpapers"
 CONFIG_DIR="$HOME/.config/niri"
@@ -11,9 +11,9 @@ TRANSITION_TYPE="grow"
 TRANSITION_DURATION=1
 TRANSITION_FPS=60
 
-# Ensure swww daemon is running
-if ! pgrep -x "swww-daemon" > /dev/null; then
-    swww-daemon &
+# Ensure awww daemon is running
+if ! pgrep -x "awww-daemon" > /dev/null; then
+    awww-daemon &
     sleep 0.5
 fi
 
@@ -21,7 +21,7 @@ case "$1" in
     --set)
         # Set specific wallpaper
         if [[ -f "$2" ]]; then
-            swww img "$2" \
+            awww img "$2" \
                 --transition-type "$TRANSITION_TYPE" \
                 --transition-duration "$TRANSITION_DURATION" \
                 --transition-fps "$TRANSITION_FPS"
@@ -35,7 +35,7 @@ case "$1" in
         if [[ -d "$WALLPAPER_DIR" ]]; then
             RANDOM_WALL=$(find "$WALLPAPER_DIR" -type f \( -name "*.jpg" -o -name "*.jpeg" -o -name "*.png" -o -name "*.webp" \) | shuf -n 1)
             if [[ -n "$RANDOM_WALL" ]]; then
-                swww img "$RANDOM_WALL" \
+                awww img "$RANDOM_WALL" \
                     --transition-type "$TRANSITION_TYPE" \
                     --transition-duration "$TRANSITION_DURATION" \
                     --transition-fps "$TRANSITION_FPS"
@@ -54,7 +54,7 @@ case "$1" in
         if [[ -d "$WALLPAPER_DIR" ]]; then
             SELECTED=$(find "$WALLPAPER_DIR" -type f \( -name "*.jpg" -o -name "*.jpeg" -o -name "*.png" -o -name "*.webp" \) | rofi -dmenu -i -p "Wallpaper")
             if [[ -n "$SELECTED" && -f "$SELECTED" ]]; then
-                swww img "$SELECTED" \
+                awww img "$SELECTED" \
                     --transition-type "$TRANSITION_TYPE" \
                     --transition-duration "$TRANSITION_DURATION" \
                     --transition-fps "$TRANSITION_FPS"
@@ -67,7 +67,7 @@ case "$1" in
     --default)
         # Set default wallpaper
         if [[ -f "$DEFAULT_WALLPAPER" ]]; then
-            swww img "$DEFAULT_WALLPAPER" \
+            awww img "$DEFAULT_WALLPAPER" \
                 --transition-type "$TRANSITION_TYPE" \
                 --transition-duration "$TRANSITION_DURATION" \
                 --transition-fps "$TRANSITION_FPS"
@@ -87,7 +87,7 @@ case "$1" in
         echo ""
         # Default action: set default wallpaper
         if [[ -f "$DEFAULT_WALLPAPER" ]]; then
-            swww img "$DEFAULT_WALLPAPER" \
+            awww img "$DEFAULT_WALLPAPER" \
                 --transition-type "$TRANSITION_TYPE" \
                 --transition-duration "$TRANSITION_DURATION" \
                 --transition-fps "$TRANSITION_FPS"

--- a/modules/nixos/wm/hyprland/default.nix
+++ b/modules/nixos/wm/hyprland/default.nix
@@ -118,7 +118,7 @@ in
       foot
       eww
       libnotify
-      swww
+      awww
       wl-clipboard
       wl-clip-persist
       cliphist

--- a/modules/nixos/wm/niri/default.nix
+++ b/modules/nixos/wm/niri/default.nix
@@ -92,7 +92,7 @@ in
 
       # Wayland utilities
       swaybg
-      swww
+      awww
       wl-clipboard
       wl-clip-persist
       cliphist


### PR DESCRIPTION
## Summary
- Renamed swww package to awww in nixpkgs across 4 files
- Updated both package references and binary names (swww-daemon → awww-daemon, swww img → awww img)

## Changes
| File | Change |
|------|--------|
| modules/nixos/wm/hyprland/default.nix | swww → awww |
| modules/nixos/wm/niri/default.nix | swww → awww |
| modules/home/wm/niri/niri_config/config.kdl | swww-daemon → awww-daemon |
| modules/home/wm/niri/niri_config/scripts/wallpaper | swww-daemon → awww-daemon, swww img → awww img |

## Verification
- [x] All swww references replaced with awww
- [ ] `sudo sys test` passes (needs to be run manually)

## Acceptance Criteria
- [x] All 4 files updated with correct substitutions
- [x] Changes committed with descriptive message
- [ ] Build verification (sudo sys test)
- [ ] Review-uat sign-off

🤖 Generated with [Claude Code](https://claude.com/claude-code)