### PR TITLE
fix(zellij): guard resurrected attaches

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -635,11 +635,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775087534,
-        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "lastModified": 1777932387,
+        "narHash": "sha256-nUYVPiqrzr36ThiQOAr5MKeGHDBSDM3OFWkz0uDjOvc=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "rev": "71a3a77326609675e9f8b51084cf23d5d1945899",
         "type": "github"
       },
       "original": {
@@ -2525,11 +2525,11 @@
         "systems": "systems_8"
       },
       "locked": {
-        "lastModified": 1777236345,
-        "narHash": "sha256-ALOqlq7bE30lsX4rA76hXeQ2aLLEpb44hS+D1+jWS88=",
+        "lastModified": 1777991353,
+        "narHash": "sha256-DFwjggMV+nzCZpwK6Obxj9F+P59rbLVowGqHETfctBk=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "a67d9cd6ff725a763afe88727aac73208ded3bf4",
+        "rev": "7986a276960b4dfaed9bb2c3c438b5ba71ae08f1",
         "type": "github"
       },
       "original": {
@@ -2818,11 +2818,11 @@
         "nixpkgs": "nixpkgs_11"
       },
       "locked": {
-        "lastModified": 1775036584,
-        "narHash": "sha256-zW0lyy7ZNNT/x8JhzFHBsP2IPx7ATZIPai4FJj12BgU=",
+        "lastModified": 1776796298,
+        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "4e0eb042b67d863b1b34b3f64d52ceb9cd926735",
+        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
         "type": "github"
       },
       "original": {
@@ -3018,11 +3018,11 @@
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_4"
       },
       "locked": {
-        "lastModified": 1778038316,
-        "narHash": "sha256-/8s6iNzWRDiosyB0Cy4ONMAbDL7xXYXQA7es3XmsiRg=",
+        "lastModified": 1778041631,
+        "narHash": "sha256-4iFBr8iTddmyctVX1I1px0VgweYG3pRFsjcdaamkEdM=",
         "owner": "sinh-x",
         "repo": "Neve",
-        "rev": "2d074688a16b28c06f0144e39bf6328b3aa81a62",
+        "rev": "174b37efdd2f709d2fdaf389ceb73d8b26e317a8",
         "type": "github"
       },
       "original": {

--- a/modules/home/cli-apps/fish/default.nix
+++ b/modules/home/cli-apps/fish/default.nix
@@ -93,7 +93,7 @@ in
         sshref = "rm ~/.ssh/known_hosts";
 
         # ----- general abbr -----
-        za = "zellij attach";
+        za = "zellij_attach_safe";
       };
       shellAliases = {
         # ----- general alias -----
@@ -231,6 +231,54 @@ in
               return 1
             end
             echo "Exit node disabled, direct routing restored"
+          '';
+        };
+        zellij_attach_safe = {
+          description = "Attach to a Zellij session with EXITED/resurrection awareness";
+          body = ''
+            if test (count $argv) -eq 0
+                command zellij attach
+                return $status
+            end
+
+            set -l session $argv[1]
+            set -l session_line
+
+            command zellij list-sessions --no-formatting 2>/dev/null | while read -l line
+                set -l listed_session (string split -m1 " " -- $line)[1]
+                if test "$listed_session" = "$session"
+                    set session_line $line
+                    break
+                end
+            end
+
+            if test -z "$session_line"
+                set_color yellow
+                echo "Zellij session '$session' was not found."
+                echo "To create a new session intentionally, run: zellij attach --create $session"
+                set_color normal
+                return 1
+            end
+
+            if string match -q "*EXITED*" -- $session_line
+                set_color yellow
+                echo "Zellij session '$session' is EXITED; attach will resurrect cached state."
+                echo "This does not reload default_layout, and may restore a blank/degraded serialized layout."
+                echo "It will not force-run resurrected commands."
+                set_color normal
+
+                read -l -P "Attach and resurrect '$session'? [y/N] " confirm
+                switch $confirm
+                    case y Y yes Yes
+                        command zellij attach $argv
+                        return $status
+                    case '*'
+                        echo "Cancelled. To start fresh safely, use a new session name."
+                        return 1
+                end
+            end
+
+            command zellij attach $argv
           '';
         };
       };

--- a/modules/home/cli-apps/zellij/layouts/default.kdl
+++ b/modules/home/cli-apps/zellij/layouts/default.kdl
@@ -96,9 +96,9 @@ layout {
                 format_left   "{mode}#[bg=#181926] {tabs}"
                 format_center "#[bg=#181926,fg=#89b4fa]{datetime}"
                 format_right  "#[bg=#181926,fg=#89b4fa]#[bg=#89b4fa,fg=#1e2030,bold] #[bg=#363a4f,fg=#89b4fa,bold] {session}{command_hostname} #[bg=#181926,fg=#363a4f,bold]"
-                format_space  ""
+                format_space  "#[bg=#181926] "
                 format_hide_on_overlength "true"
-                format_precedence "crl"
+                format_precedence "lrc"
 
                 border_enabled  "false"
                 border_char     "─"


### PR DESCRIPTION
## Summary
- Route the Fish `za` abbreviation through a safe Zellij attach helper that detects missing and EXITED sessions before attaching.
- Warn before resurrecting cached EXITED sessions so degraded serialized layouts are not mistaken for `default_layout` startup behavior.
- Adjust `zjstatus` overlength precedence so mode/tabs stay visible first on narrow/mobile SSH clients.

## Test plan
- [x] `git diff --check`
- [x] pre-commit hooks during commit: deadnix, nixfmt, statix
- [x] Drgnfly Nix eval for `programs.fish.shellAbbrs.za`
- [x] Fish helper syntax check
- [x] EXITED session prompt/cancel check with `sinh-x-pa`
- [ ] `nix flake check` blocked by existing unrelated Elderwood `modules.bspwm` option error