### PR TITLE
NX-020: Niri Ghostty-only Rofi Window Switcher

### DIFF
--- a/modules/home/wm/niri/niri_config/config.kdl
+++ b/modules/home/wm/niri/niri_config/config.kdl
@@ -213,6 +213,7 @@ binds {
     Mod+E { spawn "thunar"; }
     Mod+Shift+W { spawn "bash" "-c" "~/.config/niri/scripts/smart_spawn browser"; }
     Ctrl+Alt+W hotkey-overlay-title="Window Switcher" { spawn "rofi" "-show" "window"; }
+    Ctrl+Alt+T hotkey-overlay-title="Ghostty Switcher" { spawn "bash" "-c" "~/.config/niri/scripts/rofi_ghostty_switcher"; }
     Mod+Ctrl+W hotkey-overlay-title="Wallpaper Picker" { spawn "bash" "-c" "~/.config/niri/scripts/wallpaper --select"; }
 
     // Window management

--- a/modules/home/wm/niri/niri_config/rofi/ghostty_switcher.rasi
+++ b/modules/home/wm/niri/niri_config/rofi/ghostty_switcher.rasi
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2020-2024 Aditya Shakya <adi1090x@gmail.com>
+ **/
+
+/*****----- Global Properties -----*****/
+@import                          "shared/colors.rasi"
+@import                          "shared/fonts.rasi"
+
+/*****----- Main Window -----*****/
+window {
+    location:                    center;
+    anchor:                      center;
+    fullscreen:                  false;
+    width:                       500px;
+    x-offset:                    0px;
+    y-offset:                    0px;
+    margin:                      0px;
+    padding:                     20px;
+    border:                      2px solid;
+    border-radius:               0px;
+    border-color:                @background-alt;
+    background-color:            @background;
+    children:                    [ "listview" ];
+}
+
+/*****----- Listview -----*****/
+listview {
+    enabled:                     true;
+    columns:                     1;
+    lines:                       10;
+    cycle:                       true;
+    dynamic:                     true;
+    scrollbar:                   false;
+    layout:                      vertical;
+    reverse:                     false;
+    fixed-height:                false;
+    fixed-columns:               true;
+    spacing:                     4px;
+    background-color:            transparent;
+    text-color:                  @foreground;
+}
+
+element {
+    enabled:                     true;
+    padding:                     8px 10px;
+    border-radius:               0px;
+    background-color:            @background;
+    text-color:                  @foreground;
+}
+
+element alternate.normal {
+    background-color:            @background-alt;
+    text-color:                  @foreground;
+}
+
+element selected.normal {
+    background-color:            @selected;
+    text-color:                  @background;
+}
+
+element-text {
+    background-color:            transparent;
+    text-color:                  inherit;
+    highlight:                   inherit;
+}

--- a/modules/home/wm/niri/niri_config/rofi/ghostty_switcher.rasi
+++ b/modules/home/wm/niri/niri_config/rofi/ghostty_switcher.rasi
@@ -20,7 +20,28 @@ window {
     border-radius:               0px;
     border-color:                @background-alt;
     background-color:            @background;
-    children:                    [ "listview" ];
+    children:                    [ "inputbar", "listview" ];
+}
+
+/*****----- Inputbar -----*****/
+inputbar {
+    enabled:                     true;
+    spacing:                     0px;
+    margin:                      0px 0px 8px 0px;
+    padding:                     0px;
+    background-color:            transparent;
+    text-color:                  @foreground;
+    children:                    [ "entry" ];
+}
+
+entry {
+    padding:                     8px 12px;
+    border-radius:               0px;
+    background-color:            @background-alt;
+    text-color:                  @foreground;
+    cursor:                      text;
+    placeholder:                 "Filter...";
+    placeholder-color:           inherit;
 }
 
 /*****----- Listview -----*****/

--- a/modules/home/wm/niri/niri_config/scripts/rofi_ghostty_switcher
+++ b/modules/home/wm/niri/niri_config/scripts/rofi_ghostty_switcher
@@ -25,12 +25,15 @@ if [[ ${#titles[@]} -eq 0 ]]; then
     exit 0
 fi
 
-chosen=$(printf '%s\n' "${titles[@]}" | rofi -dmenu -p "Ghostty" -theme "$RASI")
+chosen=$(
+    for i in "${!titles[@]}"; do
+        printf '%s\0icon\037%d\n' "${titles[$i]}" "${ids[$i]}"
+    done | rofi -dmenu -p "Ghostty" -theme "$RASI"
+)
+
 [[ -z "$chosen" ]] && exit 0
 
-for i in "${!titles[@]}"; do
-    if [[ "${titles[$i]}" == "$chosen" ]]; then
-        niri msg action focus-window --id "${ids[$i]}"
-        break
-    fi
-done
+window_id="${chosen##*$'\x1f'}"
+if [[ -n "$window_id" ]]; then
+    niri msg action focus-window --id "$window_id"
+fi

--- a/modules/home/wm/niri/niri_config/scripts/rofi_ghostty_switcher
+++ b/modules/home/wm/niri/niri_config/scripts/rofi_ghostty_switcher
@@ -11,29 +11,30 @@ if [[ -z "$windows_json" ]]; then
     exit 0
 fi
 
-mapfile -t titles < <(echo "$windows_json" | jq -r '
+mapfile -t entries < <(printf '%s\n' "$windows_json" | jq -r '
     [.[] | select(.app_id == "com.mitchellh.ghostty")]
-    | if length == 0 then empty else .[] | (.title // "[Ghostty]") end
+    | if length == 0 then empty
+      else .[] | "\(.title // "[Ghostty]")\t\(.id)"
+      end
 ')
 
-mapfile -t ids < <(echo "$windows_json" | jq -r '
-    [.[] | select(.app_id == "com.mitchellh.ghostty")]
-    | if length == 0 then empty else .[] | .id end
-')
-
-if [[ ${#titles[@]} -eq 0 ]]; then
+if [[ ${#entries[@]} -eq 0 ]]; then
     exit 0
 fi
 
-chosen=$(
+titles=()
+ids=()
+for entry in "${entries[@]}"; do
+    titles+=("${entry%$'\t'*}")
+    ids+=("${entry##*$'\t'}")
+done
+
+chosen_index=$(
     for i in "${!titles[@]}"; do
-        printf '%s\0icon\037%d\n' "${titles[$i]}" "${ids[$i]}"
-    done | rofi -dmenu -p "Ghostty" -theme "$RASI"
+        printf '[%d] %s\n' "$((i + 1))" "${titles[$i]}"
+    done | rofi -dmenu -format i -p "Ghostty" -theme "$RASI"
 )
 
-[[ -z "$chosen" ]] && exit 0
+[[ -z "$chosen_index" ]] && exit 0
 
-window_id="${chosen##*$'\x1f'}"
-if [[ -n "$window_id" ]]; then
-    niri msg action focus-window --id "$window_id"
-fi
+niri msg action focus-window --id "${ids[$chosen_index]}"

--- a/modules/home/wm/niri/niri_config/scripts/rofi_ghostty_switcher
+++ b/modules/home/wm/niri/niri_config/scripts/rofi_ghostty_switcher
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+DIR="$HOME/.config/niri"
+RASI="$DIR/rofi/ghostty_switcher.rasi"
+
+windows_json=$(niri msg --json windows 2>/dev/null)
+if [[ -z "$windows_json" ]]; then
+    exit 0
+fi
+
+entries=$(echo "$windows_json" | jq -r '
+    [.[] | select(.app_id == "com.mitchellh.ghostty")] as $ghostty
+    | if ($ghostty | length) == 0 then
+        ""
+    else
+        $ghostty[]
+        | (.title // "[Ghostty]") as $title
+        | "\($title)\u0000icon\u001f\(.id)"
+    end
+')
+
+if [[ -z "$entries" ]]; then
+    exit 0
+fi
+
+chosen=$(echo "$entries" | rofi -dmenu -p "Ghostty" -theme "$RASI")
+[[ -z "$chosen" ]] && exit 0
+
+window_id=$(echo "$chosen" | sed 's/.*\x00icon\x1f//')
+if [[ -n "$window_id" ]]; then
+    niri msg action focus-window --id "$window_id"
+fi

--- a/modules/home/wm/niri/niri_config/scripts/rofi_ghostty_switcher
+++ b/modules/home/wm/niri/niri_config/scripts/rofi_ghostty_switcher
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+## Ghostty-only window switcher for Niri via Rofi dmenu.
+## Queries open windows via niri IPC, filters to com.mitchellh.ghostty,
+## presents them in Rofi, and focuses the selected window.
 
 DIR="$HOME/.config/niri"
 RASI="$DIR/rofi/ghostty_switcher.rasi"
@@ -8,25 +11,26 @@ if [[ -z "$windows_json" ]]; then
     exit 0
 fi
 
-entries=$(echo "$windows_json" | jq -r '
-    [.[] | select(.app_id == "com.mitchellh.ghostty")] as $ghostty
-    | if ($ghostty | length) == 0 then
-        ""
-    else
-        $ghostty[]
-        | (.title // "[Ghostty]") as $title
-        | "\($title)\u0000icon\u001f\(.id)"
-    end
+mapfile -t titles < <(echo "$windows_json" | jq -r '
+    [.[] | select(.app_id == "com.mitchellh.ghostty")]
+    | if length == 0 then empty else .[] | (.title // "[Ghostty]") end
 ')
 
-if [[ -z "$entries" ]]; then
+mapfile -t ids < <(echo "$windows_json" | jq -r '
+    [.[] | select(.app_id == "com.mitchellh.ghostty")]
+    | if length == 0 then empty else .[] | .id end
+')
+
+if [[ ${#titles[@]} -eq 0 ]]; then
     exit 0
 fi
 
-chosen=$(echo "$entries" | rofi -dmenu -p "Ghostty" -theme "$RASI")
+chosen=$(printf '%s\n' "${titles[@]}" | rofi -dmenu -p "Ghostty" -theme "$RASI")
 [[ -z "$chosen" ]] && exit 0
 
-window_id=$(echo "$chosen" | sed 's/.*\x00icon\x1f//')
-if [[ -n "$window_id" ]]; then
-    niri msg action focus-window --id "$window_id"
-fi
+for i in "${!titles[@]}"; do
+    if [[ "${titles[$i]}" == "$chosen" ]]; then
+        niri msg action focus-window --id "${ids[$i]}"
+        break
+    fi
+done


### PR DESCRIPTION
## Summary
- Adds `Ctrl+Alt+T` keybinding to niri config that opens a Rofi menu listing only Ghostty terminal windows
- Creates `rofi_ghostty_switcher` shell script that queries niri IPC for Ghostty windows, presents them in Rofi, and focuses the selected one
- Creates `ghostty_switcher.rasi` Rofi theme importing shared colors/fonts
- Preserves existing `Ctrl+Alt+W` all-window switcher without modification
- Ghostty `app_id` filter uses `com.mitchellh.ghostty`, matching the existing window rule at config.kdl:177

## Acceptance Criteria
- AC1: Ctrl+Alt+T opens Rofi menu listing only Ghostty windows
- AC2: Selecting a window entry focuses that Ghostty window
- AC3: ESC closes the menu without any focus change
- AC4: Zero Ghostty windows exits cleanly (status 0, no crash, no spawn)
- AC5: Ctrl+Alt+W continues to open all-window switcher
- AC6: Ghostty switcher uses dedicated .rasi importing shared colors/fonts
- AC7: Script uses niri msg --json windows | jq pattern consistent with existing scripts
- AC8: All existing keybindings and behaviors remain unchanged

## Changed Files
- `modules/home/wm/niri/niri_config/rofi/ghostty_switcher.rasi` (new)
- `modules/home/wm/niri/niri_config/scripts/rofi_ghostty_switcher` (new)
- `modules/home/wm/niri/niri_config/config.kdl` (+1 binding line)

## Verification
- `niri validate` at runtime
- Manual UAT per `agent-teams/requirements/artifacts/2026-05-06-niri-ghostty-switcher-uat.md`