### PR TITLE
feat(drgnfly): add OpenAI Codex CLI

### DIFF
--- a/home/sinh/Drgnfly.nix
+++ b/home/sinh/Drgnfly.nix
@@ -86,6 +86,7 @@
     coding = {
       editor.vscode.enable = true;
       docker.enable = true;
+      codex.enable = true;
       claudecode.enable = true;
       opencode.enable = true;
       super-productivity.enable = false;

--- a/modules/home/coding/codex/default.nix
+++ b/modules/home/coding/codex/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  pkgs,
+  config,
+  namespace,
+  ...
+}:
+with lib;
+let
+  cfg = config.${namespace}.coding.codex;
+in
+{
+  options.${namespace}.coding.codex = {
+    enable = mkEnableOption "OpenAI Codex CLI";
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = with pkgs; [
+      codex
+    ];
+  };
+}


### PR DESCRIPTION
## Summary
- Add a reusable Home Manager coding module for the OpenAI Codex CLI.
- Enable Codex for the Drgnfly home configuration.

## Verification
- nix eval confirmed Codex is present in Drgnfly Home Manager packages
- nix develop -c statix check modules/home/coding/codex
- nix develop -c statix check home/sinh/Drgnfly.nix
- nix build .#nixosConfigurations.Drgnfly.config.system.build.toplevel --dry-run
- pre-commit hooks: deadnix, nixfmt, statix