### PR TITLE
chore(drgnfly): disable ollama and zeroclaw autostart

### DIFF
--- a/home/sinh/Drgnfly.nix
+++ b/home/sinh/Drgnfly.nix
@@ -40,7 +40,10 @@
 
   sinh-x = {
     apps = {
-      sinh-x.enable = true;
+      sinh-x = {
+        enable = true;
+        zeroclaw.enable = false;
+      };
       web.zen-browser.enable = true;
       web.browser = {
         chrome = true;

--- a/modules/home/apps/sinh-x/default.nix
+++ b/modules/home/apps/sinh-x/default.nix
@@ -17,16 +17,24 @@ in
 {
   options.${namespace}.apps.sinh-x = {
     enable = mkEnableOption "Sinh-x apps";
+
+    zeroclaw.enable = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Enable the ZeroClaw daemon user service";
+    };
   };
 
   config = mkIf cfg.enable {
-    home.packages = with pkgs; [
-      sinh-x-wallpaper
-      avo
-      sinh-x-zeroclaw
-    ];
+    home.packages =
+      with pkgs;
+      [
+        sinh-x-wallpaper
+        avo
+      ]
+      ++ optionals cfg.zeroclaw.enable [ sinh-x-zeroclaw ];
 
-    systemd.user.services.zeroclaw = {
+    systemd.user.services.zeroclaw = mkIf cfg.zeroclaw.enable {
       Unit = {
         Description = "ZeroClaw daemon";
         After = [ "default.target" ];

--- a/systems/x86_64-linux/Drgnfly/default.nix
+++ b/systems/x86_64-linux/Drgnfly/default.nix
@@ -41,7 +41,7 @@
     };
 
     docker.enable = true;
-    ollama.enable = true;
+    ollama.enable = false;
     thermal-printer.enable = true;
 
     # network


### PR DESCRIPTION
## Summary
- Disable the Drgnfly Ollama NixOS module so it does not autostart.
- Add a ZeroClaw home-manager toggle and disable its user service on Drgnfly.

## Verification
- nix develop --command nixfmt --check home/sinh/Drgnfly.nix modules/home/apps/sinh-x/default.nix systems/x86_64-linux/Drgnfly/default.nix
- nix flake check