### PR TITLE
chore(pa-platform): use remote develop input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2691,8 +2691,8 @@
         ]
       },
       "locked": {
-        "lastModified": 1778406976,
-        "narHash": "sha256-7mbmVQ0/Tpv2PmOElPPtgA5qEu6s2//kcdCT2fw0qX0=",
+        "lastModified": 1778470982,
+        "narHash": "sha256-80LIN/i27MowW6Kp3+lCo9Cv45MaZGx9zMWngWpJbE4=",
         "path": "/home/sinh/git-repos/sinh-x/tools/pa-platform",
         "type": "path"
       },

--- a/flake.lock
+++ b/flake.lock
@@ -2691,8 +2691,8 @@
         ]
       },
       "locked": {
-        "lastModified": 1778406768,
-        "narHash": "sha256-L0Rc7nWpcluOIpEGT2cBPpwrWeQfIFbl1ay7ORDCsts=",
+        "lastModified": 1778406976,
+        "narHash": "sha256-7mbmVQ0/Tpv2PmOElPPtgA5qEu6s2//kcdCT2fw0qX0=",
         "path": "/home/sinh/git-repos/sinh-x/tools/pa-platform",
         "type": "path"
       },

--- a/flake.lock
+++ b/flake.lock
@@ -2691,14 +2691,18 @@
         ]
       },
       "locked": {
-        "lastModified": 1778470982,
-        "narHash": "sha256-80LIN/i27MowW6Kp3+lCo9Cv45MaZGx9zMWngWpJbE4=",
-        "path": "/home/sinh/git-repos/sinh-x/tools/pa-platform",
-        "type": "path"
+        "lastModified": 1778496515,
+        "narHash": "sha256-31CP7S9T/U4wr+ezXgDaPAO9o0PjrEZ30RZrW+aJ8ss=",
+        "ref": "develop",
+        "rev": "b577246f2db7522b29a189dcf01cc11d8a96c954",
+        "revCount": 299,
+        "type": "git",
+        "url": "ssh://git@github.com/sinh-x/pa-platform"
       },
       "original": {
-        "path": "/home/sinh/git-repos/sinh-x/tools/pa-platform",
-        "type": "path"
+        "ref": "develop",
+        "type": "git",
+        "url": "ssh://git@github.com/sinh-x/pa-platform"
       }
     },
     "personal-google-mcp": {

--- a/flake.lock
+++ b/flake.lock
@@ -2691,18 +2691,14 @@
         ]
       },
       "locked": {
-        "lastModified": 1778064208,
-        "narHash": "sha256-u6FSIkh9lJQC+P3eYO1DuDkV3k/w3SHiE2qyyGtOoQk=",
-        "owner": "sinh-x",
-        "repo": "pa-platform",
-        "rev": "74440399383a8cc03f203910b0252a115219389f",
-        "type": "github"
+        "lastModified": 1778406768,
+        "narHash": "sha256-L0Rc7nWpcluOIpEGT2cBPpwrWeQfIFbl1ay7ORDCsts=",
+        "path": "/home/sinh/git-repos/sinh-x/tools/pa-platform",
+        "type": "path"
       },
       "original": {
-        "owner": "sinh-x",
-        "ref": "develop",
-        "repo": "pa-platform",
-        "type": "github"
+        "path": "/home/sinh/git-repos/sinh-x/tools/pa-platform",
+        "type": "path"
       }
     },
     "personal-google-mcp": {

--- a/flake.nix
+++ b/flake.nix
@@ -115,7 +115,8 @@
     };
 
     pa-platform = {
-      url = "github:sinh-x/pa-platform/develop";
+      # Local checkout for testing PA platform changes before pushing upstream.
+      url = "/home/sinh/git-repos/sinh-x/tools/pa-platform";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -115,8 +115,8 @@
     };
 
     pa-platform = {
-      # Local checkout for testing PA platform changes before pushing upstream.
-      url = "/home/sinh/git-repos/sinh-x/tools/pa-platform";
+      url = "git+ssh://git@github.com/sinh-x/pa-platform?ref=develop";
+      # url = "/home/sinh/git-repos/sinh-x/tools/pa-platform";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 


### PR DESCRIPTION
## Summary
- Point pa-platform at remote GitHub develop over SSH.
- Refresh the flake lock to the current pa-platform develop revision.
- Keep the local checkout path as a commented fallback for future testing.

## Verification
- nix flake metadata --json
- nix build .#pkgs.x86_64-linux.nixpkgs.opa --no-link