### PR TITLE
NX-024: Fix fish zellij za completion

### DIFF
--- a/modules/home/cli-apps/fish/default.nix
+++ b/modules/home/cli-apps/fish/default.nix
@@ -60,6 +60,8 @@ in
             command zellij list-sessions --short --no-formatting 2>/dev/null
         end
 
+        complete -c za -f
+        complete -c za -a '(__zsafe_sessions)'
         complete -c zsafe -f
         complete -c zsafe -a '(__zsafe_sessions)'
 
@@ -100,13 +102,13 @@ in
         sshref = "rm ~/.ssh/known_hosts";
 
         # ----- general abbr -----
-        za = "zellij_attach_safe";
       };
       shellAliases = {
         # ----- general alias -----
         vim = "nvim";
         ssha = "ssh-add";
         sshconfig = "nvim ~/.ssh/config";
+        za = "zellij attach";
         zsafe = "zellij_attach_safe";
       };
       functions = {


### PR DESCRIPTION
## Summary
- Makes `za` a raw fish alias for `zellij attach` instead of the safe wrapper.
- Adds explicit `za` session completion using the existing Zellij session source.
- Preserves `zsafe` alias and completion behavior.

## Acceptance Criteria
- [x] AC-1: `za <session>` invokes raw `zellij attach <session>` and bypasses `zellij_attach_safe`.
- [x] AC-2: `za` is absent from `shellAbbrs` and present in `shellAliases`.
- [x] AC-3: `za` has explicit session completion.
- [x] AC-4: `zsafe` remains the safe wrapper and keeps session completion.
- [x] AC-5: Non-sudo repository verification completed by builder deployment d-de38cb.

Ticket: NX-024
Orchestration: agent-teams/builder/artifacts/2026-05-12-fish-zellij-za-completion-orchestration-report.md