### PR TITLE
fix(zellij): keep status visible when overlength

### DIFF
--- a/modules/home/cli-apps/zellij/layouts/default.kdl
+++ b/modules/home/cli-apps/zellij/layouts/default.kdl
@@ -97,7 +97,7 @@ layout {
                 format_center "#[bg=#181926,fg=#89b4fa]{datetime}"
                 format_right  "#[bg=#181926,fg=#89b4fa]#[bg=#89b4fa,fg=#1e2030,bold] #[bg=#363a4f,fg=#89b4fa,bold] {session}{command_hostname} #[bg=#181926,fg=#363a4f,bold]"
                 format_space  "#[bg=#181926] "
-                format_hide_on_overlength "true"
+                format_hide_on_overlength "false"
                 format_precedence "lrc"
 
                 border_enabled  "false"


### PR DESCRIPTION
## Summary
- Prevent the Zellij `zjstatus` bar from disappearing when status content exceeds the available width.
- Keep the existing layout and status format unchanged otherwise.

## Verification
- Pre-commit hooks ran during commit and skipped non-applicable checks for this KDL-only change.