### PR TITLE
NX-025: Add Vivaldi browser as primary on Drgnfly

### DIFF
--- a/home/sinh/Drgnfly.nix
+++ b/home/sinh/Drgnfly.nix
@@ -45,10 +45,7 @@
         zeroclaw.enable = false;
       };
       web = {
-        zen-browser.enable = true;
         browser = {
-          chrome = true;
-          brave = true;
           edge = true;
         };
         vivaldi.enable = true;

--- a/home/sinh/Drgnfly.nix
+++ b/home/sinh/Drgnfly.nix
@@ -29,7 +29,7 @@
 
     sessionVariables = {
       EDITOR = "nvim";
-      BROWSER = "zen-twilight";
+      BROWSER = "vivaldi";
       LEFT_MONITOR = "eDP-1";
     };
 
@@ -44,11 +44,14 @@
         enable = true;
         zeroclaw.enable = false;
       };
-      web.zen-browser.enable = true;
-      web.browser = {
-        chrome = true;
-        brave = true;
-        edge = true;
+      web = {
+        zen-browser.enable = true;
+        browser = {
+          chrome = true;
+          brave = true;
+          edge = true;
+        };
+        vivaldi.enable = true;
       };
       utilities.enable = true;
       themes.enable = true;

--- a/home/sinh/niri-extras.nix
+++ b/home/sinh/niri-extras.nix
@@ -70,7 +70,7 @@ _: {
 
       // Named workspaces - External monitor
       Mod+6 hotkey-overlay-title="Ext: Terminal" { focus-workspace "ext-term"; }
-      Mod+7 hotkey-overlay-title="Ext: Browser" { focus-workspace "ext-browser"; }
+      Mod+7 hotkey-overlay-title="Ext: Vivaldi" { focus-workspace "ext-browser"; }
       Mod+8 hotkey-overlay-title="Ext: Code" { focus-workspace "ext-code"; }
 
       // Move window to workspace - Chat & Email

--- a/modules/home/apps/web/vivaldi/default.nix
+++ b/modules/home/apps/web/vivaldi/default.nix
@@ -1,0 +1,20 @@
+{
+  lib,
+  pkgs,
+  config,
+  namespace,
+  ...
+}:
+with lib;
+let
+  cfg = config.${namespace}.apps.web.vivaldi;
+in
+{
+  options.${namespace}.apps.web.vivaldi = {
+    enable = mkEnableOption "Vivaldi browser";
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.vivaldi ];
+  };
+}

--- a/modules/home/cli-apps/utilities/default.nix
+++ b/modules/home/cli-apps/utilities/default.nix
@@ -149,17 +149,17 @@ in
         "image/svg+xml" = "swayimg.desktop";
         "image/x-xpixmap" = "swayimg.desktop";
 
-        # Browser - zen-twilight
-        "x-scheme-handler/http" = "zen-twilight.desktop";
-        "x-scheme-handler/https" = "zen-twilight.desktop";
-        "x-scheme-handler/chrome" = "zen-twilight.desktop";
-        "text/html" = "zen-twilight.desktop";
-        "application/xhtml+xml" = "zen-twilight.desktop";
-        "application/x-extension-htm" = "zen-twilight.desktop";
-        "application/x-extension-html" = "zen-twilight.desktop";
-        "application/x-extension-shtml" = "zen-twilight.desktop";
-        "application/x-extension-xhtml" = "zen-twilight.desktop";
-        "application/x-extension-xht" = "zen-twilight.desktop";
+        # Browser - vivaldi
+        "x-scheme-handler/http" = "vivaldi.desktop";
+        "x-scheme-handler/https" = "vivaldi.desktop";
+        "x-scheme-handler/chrome" = "vivaldi.desktop";
+        "text/html" = "vivaldi.desktop";
+        "application/xhtml+xml" = "vivaldi.desktop";
+        "application/x-extension-htm" = "vivaldi.desktop";
+        "application/x-extension-html" = "vivaldi.desktop";
+        "application/x-extension-shtml" = "vivaldi.desktop";
+        "application/x-extension-xhtml" = "vivaldi.desktop";
+        "application/x-extension-xht" = "vivaldi.desktop";
 
         # Apps
         "x-scheme-handler/viber" = "viber.desktop";

--- a/modules/home/impermanence/default.nix
+++ b/modules/home/impermanence/default.nix
@@ -64,6 +64,8 @@ in
         ".config/zen"
         ".config/BraveSoftware"
         ".config/google-chrome"
+        ".config/vivaldi"
+        ".cache/vivaldi"
 
         # === Password Manager ===
         ".config/Bitwarden"

--- a/modules/home/wm/niri/niri_config/config.kdl
+++ b/modules/home/wm/niri/niri_config/config.kdl
@@ -180,7 +180,7 @@ window-rule {
 
 // Browser -> open on main-browser
 window-rule {
-    match app-id="zen-twilight"
+    match app-id="vivaldi"
     open-on-workspace "main-browser"
 }
 

--- a/modules/home/wm/niri/niri_config/scripts/smart_spawn
+++ b/modules/home/wm/niri/niri_config/scripts/smart_spawn
@@ -10,7 +10,7 @@ APP_TYPE="$1"
 
 # Define apps
 TERMINAL="ghostty"
-BROWSER="${BROWSER:-zen-twilight}"
+BROWSER="${BROWSER:-vivaldi}"
 
 # Define output names
 MAIN_OUTPUT="eDP-1"

--- a/modules/home/wm/niri/niri_config/scripts/startup_apps
+++ b/modules/home/wm/niri/niri_config/scripts/startup_apps
@@ -20,7 +20,7 @@ Telegram &
 viber &
 
 # Phase 2: Browser and productivity (window rule -> main-browser / email workspace)
-zen-twilight &
+vivaldi &
 logseq &
 
 # Phase 3: Terminal last so it gets focus (window rule -> main-term workspace)


### PR DESCRIPTION
## Summary
- Created Vivaldi home-manager module (`modules/home/apps/web/vivaldi/default.nix`)
- Enabled Vivaldi on Drgnfly, made it default browser ($BROWSER=vivaldi)
- Updated MIME type associations from zen-twilight to vivaldi
- Updated niri keyboard shortcut from "Ext: Browser" to "Ext: Vivaldi"
- Added impermanence paths for ~/.config/vivaldi and ~/.cache/vivaldi

## Acceptance Criteria
- [ ] AC-1: Vivaldi installs and launches via `sudo sys rebuild`
- [ ] AC-7: $BROWSER=vivaldi, MIME types point to vivaldi.desktop, Mod+7 opens Vivaldi
- [ ] AC-8: ~/.config/vivaldi and ~/.cache/vivaldi persist across reboots

## Changes
| File | Change |
|---|---|
| `modules/home/apps/web/vivaldi/default.nix` | New module |
| `home/sinh/Drgnfly.nix` | Enable vivaldi + BROWSER=vivaldi |
| `modules/home/cli-apps/utilities/default.nix` | MIME types vivaldi.desktop |
| `home/sinh/niri-extras.nix` | Ext: Browser → Ext: Vivaldi |
| `modules/home/impermanence/default.nix` | Add vivaldi state dirs |

Zen Browser remains installed as secondary.