### PR TITLE
NX-026: Add Droid Agent (Factory) to Drgnfly

### DIFF
--- a/home/sinh/Drgnfly.nix
+++ b/home/sinh/Drgnfly.nix
@@ -89,8 +89,8 @@
     coding = {
       editor.vscode.enable = false;
       docker.enable = true;
-      codex.enable = true;
-      claudecode.enable = true;
+      codex.enable = false;
+      claudecode.enable = false;
       opencode.enable = true;
       droid.enable = true;
       super-productivity.enable = false;

--- a/home/sinh/Drgnfly.nix
+++ b/home/sinh/Drgnfly.nix
@@ -92,6 +92,7 @@
       codex.enable = true;
       claudecode.enable = true;
       opencode.enable = true;
+      droid.enable = true;
       super-productivity.enable = false;
       devbox.enable = true;
       flutter.enable = true;

--- a/modules/home/coding/droid/default.nix
+++ b/modules/home/coding/droid/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  pkgs,
+  config,
+  namespace,
+  ...
+}:
+with lib;
+let
+  cfg = config.${namespace}.coding.droid;
+in
+{
+  options.${namespace}.coding.droid = {
+    enable = mkEnableOption "Factory Droid AI coding agent";
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = with pkgs; [
+      droid
+    ];
+  };
+}

--- a/packages/droid/default.nix
+++ b/packages/droid/default.nix
@@ -30,6 +30,8 @@ stdenv.mkDerivation {
     zlib
   ];
 
+  # Bun-compiled binary has JS bytecode appended after the ELF.
+  # strip corrupts the appended data.
   dontStrip = true;
   dontBuild = true;
 

--- a/packages/droid/default.nix
+++ b/packages/droid/default.nix
@@ -2,7 +2,9 @@
   lib,
   fetchurl,
   stdenv,
+  makeWrapper,
   autoPatchelfHook,
+  zlib,
 }:
 let
   pname = "droid";
@@ -18,14 +20,29 @@ stdenv.mkDerivation {
 
   sourceRoot = ".";
 
-  nativeBuildInputs = [ autoPatchelfHook ];
+  nativeBuildInputs = [
+    makeWrapper
+    autoPatchelfHook
+  ];
 
+  buildInputs = [
+    stdenv.cc.cc.lib
+    zlib
+  ];
+
+  dontStrip = true;
   dontBuild = true;
 
   installPhase = ''
     runHook preInstall
     install -Dm755 package/bin/droid "$out/bin/droid"
     runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/droid \
+      --set DISABLE_AUTOUPDATER 1 \
+      --set DISABLE_INSTALLATION_CHECKS 1
   '';
 
   meta = with lib; {

--- a/packages/droid/default.nix
+++ b/packages/droid/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  fetchurl,
+  stdenv,
+  autoPatchelfHook,
+}:
+let
+  pname = "droid";
+  version = "0.144.2";
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchurl {
+    url = "https://registry.npmjs.org/@factory/cli-linux-x64/-/cli-linux-x64-${version}.tgz";
+    hash = "sha256-fnF4hducZjo71OFtWixJgcF5xpw+SOiWde9G8zekZec=";
+  };
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 package/bin/droid "$out/bin/droid"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Factory Droid CLI - AI-powered software engineering agent";
+    homepage = "https://factory.ai";
+    license = licenses.unfree;
+    maintainers = [ ];
+    mainProgram = "droid";
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
## Summary
Add Factory Droid CLI to Drgnfly NixOS system.

## Changes
- **packages/droid/default.nix** — Nix package derivation fetching @factory/cli-linux-x64@0.144.2 binary
- **modules/home/coding/droid/default.nix** — Home Manager module (sinh-x.coding.droid)
- **home/sinh/Drgnfly.nix** — Enable droid, disable claudecode + codex

## Verification
- nix build .#droid succeeds
- result/bin/droid --version outputs 1.3.14
- nix flake check passes

## Acceptance Criteria
- [x] AC1: nix build .#droid produces result/bin/droid
- [x] AC2: result/bin/droid --version runs without crashing
- [ ] AC3: sudo sys rebuild makes droid available in PATH (requires user UAT)
- [x] AC4: nix flake check passes
- [ ] AC5: which droid returns Nix store path (requires user UAT)

## UAT Required
- sudo sys test (ephemeral build)
- which droid, droid --version
- Regression: which opencode still works