### PR TITLE
NX-035: Increase /tmp tmpfs to 64GB on Drgnfly

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2783,8 +2783,8 @@
         ]
       },
       "locked": {
-        "lastModified": 1783726026,
-        "narHash": "sha256-NZFco7aF2pUTMPEwPJid8lJTElarjM9qbKtE0ot5XV8=",
+        "lastModified": 1783734648,
+        "narHash": "sha256-5tcv0lUBx256p/Q6aJbWYuRSzaWGHrGz8UdtGqUgQnk=",
         "path": "/home/sinh/git-repos/sinh-x/tools/pa-platform",
         "type": "path"
       },

--- a/modules/nixos/impermanence/default.nix
+++ b/modules/nixos/impermanence/default.nix
@@ -26,6 +26,12 @@ in
       default = [ ];
       description = "Users whose entire home directories should be persisted";
     };
+
+    tmpSize = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "Size of /tmp tmpfs (e.g. \"64G\"). Null uses NixOS default (half of RAM).";
+    };
   };
 
   config = mkIf cfg.enable {
@@ -98,5 +104,8 @@ in
 
     # Use tmpfs for /tmp
     boot.tmp.useTmpfs = true;
+
+    # Optional tmpfs size override
+    boot.tmp.tmpfsSize = mkIf (cfg.tmpSize != null) cfg.tmpSize;
   };
 }

--- a/systems/x86_64-linux/Drgnfly/default.nix
+++ b/systems/x86_64-linux/Drgnfly/default.nix
@@ -65,6 +65,7 @@
     impermanence = {
       enable = true;
       users = [ "sinh" ]; # Persist entire home directory
+      tmpSize = "64G"; # 64GB /tmp tmpfs for build cache
     };
   };
 


### PR DESCRIPTION
## Summary
Add `modules.impermanence.tmpSize` option to impermanence NixOS module, allowing hosts to set a custom `/tmp` tmpfs size. Set to `"64G"` on Drgnfly for large builds.

## Changes
- `modules/nixos/impermanence/default.nix`: Add `tmpSize` option + conditional `boot.tmp.tmpfsSize`
- `systems/x86_64-linux/Drgnfly/default.nix`: Set `impermanence.tmpSize = "64G"`

## Verification
- `nix flake check` passes for all hosts
- `nix eval .#nixosConfigurations.Drgnfly.config.boot.tmp.tmpfsSize` returns `"64G"`
- Review-auto: 0 findings across Code Quality, Security, Ops

## Commits
- `9deb4e0` feat(impermanence): phase 1 - add tmpSize option
- `d8307d1` feat(impermanence): phase 2 - set tmpSize to 64G on Drgnfly