### PR TITLE
NX-036: Herdr Agent Navigation Shortcuts

### DIFF
--- a/modules/home/cli-apps/fish/default.nix
+++ b/modules/home/cli-apps/fish/default.nix
@@ -73,7 +73,7 @@ in
         complete -c hr -a '(__herdr_sessions)'
 
         function __herdr_agents
-            command herdr agent list --json 2>/dev/null | jq -r '.result.agents[].agent' 2>/dev/null
+            command herdr agent list 2>/dev/null | jq -r '.result.agents[].agent' 2>/dev/null
         end
 
         complete -c ha -f
@@ -281,7 +281,11 @@ in
             if test -z "$label"
                 set label "unnamed"
             end
-            command herdr agent rename "$label" 2>/dev/null
+            set -l focused_id (command herdr agent list 2>/dev/null | jq -r '.result.agents[] | select(.focused == true) | .terminal_id' 2>/dev/null)
+            if test -z "$focused_id"
+                return
+            end
+            command herdr agent rename "$focused_id" "$label" 2>/dev/null
           '';
         };
         zellij_attach_safe = {

--- a/modules/home/cli-apps/fish/default.nix
+++ b/modules/home/cli-apps/fish/default.nix
@@ -72,6 +72,13 @@ in
         complete -c hr -f
         complete -c hr -a '(__herdr_sessions)'
 
+        function __herdr_agents
+            command herdr agent list --json 2>/dev/null | jq -r '.result.agents[].agent' 2>/dev/null
+        end
+
+        complete -c ha -f
+        complete -c ha -a '(__herdr_agents)'
+
         fish_vi_key_bindings
 
       '';
@@ -249,6 +256,16 @@ in
               return 1
             end
             echo "Exit node disabled, direct routing restored"
+          '';
+        };
+        ha = {
+          description = "Focus a herdr agent pane by label";
+          body = ''
+            if test (count $argv) -eq 0
+                echo "Usage: ha <agent-label>"
+                return 1
+            end
+            command herdr agent focus $argv[1]
           '';
         };
         zellij_attach_safe = {

--- a/modules/home/cli-apps/fish/default.nix
+++ b/modules/home/cli-apps/fish/default.nix
@@ -79,6 +79,9 @@ in
         complete -c ha -f
         complete -c ha -a '(__herdr_agents)'
 
+        # Auto-label herdr agent pane with CWD basename on startup
+        __auto_label_herdr_pane
+
         fish_vi_key_bindings
 
       '';
@@ -266,6 +269,19 @@ in
                 return 1
             end
             command herdr agent focus $argv[1]
+          '';
+        };
+        __auto_label_herdr_pane = {
+          description = "Auto-label herdr agent pane with CWD project name on startup";
+          body = ''
+            if not command -sq herdr
+                return
+            end
+            set -l label (basename (pwd) 2>/dev/null)
+            if test -z "$label"
+                set label "unnamed"
+            end
+            command herdr agent rename "$label" 2>/dev/null
           '';
         };
         zellij_attach_safe = {

--- a/modules/home/cli-apps/herdr/config.toml
+++ b/modules/home/cli-apps/herdr/config.toml
@@ -17,3 +17,15 @@ new_tab = ["prefix+c", "alt+c", "ctrl+alt+c"]
 split_vertical = ["prefix+d", "alt+d", "ctrl+alt+d"]
 zoom = ["prefix+z", "alt+z", "ctrl+alt+z"]
 switch_workspace = ["prefix+1", "prefix+2", "prefix+3", "prefix+4", "prefix+5", "prefix+6", "prefix+7", "prefix+8", "prefix+9", "ctrl+alt+1", "ctrl+alt+2", "ctrl+alt+3", "ctrl+alt+4", "ctrl+alt+5", "ctrl+alt+6", "ctrl+alt+7", "ctrl+alt+8", "ctrl+alt+9"]
+focus_agent = ["prefix+alt+1", "prefix+alt+2", "prefix+alt+3", "prefix+alt+4", "prefix+alt+5", "prefix+alt+6", "prefix+alt+7", "prefix+alt+8", "prefix+alt+9"]
+workspace_picker = ["prefix+w"]
+
+[[keys.command]]
+keys = ["prefix+a"]
+type = "pane"
+command = '''
+target=$($HERDR_BIN_PATH agent list | jq -r '.result.agents[] | "\(.terminal_id)\t\(.agent)\t\(.workspace_id)\t\(.cwd)"' 2>/dev/null | fzf --with-nth=2.. --prompt="Agent > " | awk '{print $1}')
+if [ -n "$target" ]; then
+  $HERDR_BIN_PATH agent focus "$target"
+fi
+'''

--- a/modules/home/cli-apps/herdr/default.nix
+++ b/modules/home/cli-apps/herdr/default.nix
@@ -18,6 +18,7 @@ in
     home.packages = [
       pkgs.herdr
       pkgs.jq
+      pkgs.fzf
     ];
 
     xdg.configFile."herdr/config.toml".source = ./config.toml;

--- a/modules/nixos/wifi/default.nix
+++ b/modules/nixos/wifi/default.nix
@@ -288,6 +288,9 @@ let
     "Every Half Coffee Roasters" = {
       pskRaw = "ext:sg_everyhalf_bt";
     };
+    "Latica Coffee" = {
+      pskRaw = "ext:sg_latica";
+    };
     "BELLA CAFE 3" = {
       pskRaw = "ext:kh_bellacafe";
     };


### PR DESCRIPTION
Add fast keyboard shortcut navigation to herdr agent panes within a session.

## Changes
- **Phase 1** (829a55e): config.toml keybindings — `focus_agent` (`prefix+alt+1..9`), agent picker `[[keys.command]]` (`prefix+a`), `workspace_picker` (`prefix+w`), `pkgs.fzf` dependency
- **Phase 2** (5b1a392): Shell-level agent functions — `ha` fish function, `__herdr_agents` tab-completion
- **Phase 3** (58693be): Auto-labeling hook — `__auto_label_herdr_pane` function for CWD-based agent labeling

## Acceptance Criteria
- [ ] AC1: `prefix+alt+N` focuses Nth agent pane by index
- [ ] AC2: `prefix+a` opens fzf agent picker overlay
- [ ] AC3: `ha <agent-label>` focuses matching agent
- [ ] AC4: Agent panes auto-labeled with project name
- [ ] AC5: `prefix+w` workspace picker shows grouped agents

## Verification
All code passes: deadnix, nixfmt, statix

Closes NX-036